### PR TITLE
Add .gitignore for spawned-agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/worktrees/


### PR DESCRIPTION
Resolves part 1 of #18.

## What changed
One new file, `.gitignore`, with one line: `.claude/worktrees/`.

## Why
Issue #18, exposed by #8. `claude -p --worktree` creates each spawned ticket agent's worktree under `.claude/worktrees/`. Once agents run in parallel, every agent's worktree would appear as untracked noise in every other agent's `git status`.

## Proof it ran
Verified in the working checkout on this branch: with `.claude/worktrees/` present, `git status --short` is empty and `git check-ignore -v .claude/worktrees/x` reports the rule as matching. No test suite exists in this repo.

## Riskiest hunks
`.gitignore:1` — the only line. Scoped to `.claude/worktrees/` deliberately, not all of `.claude/`, so a future `.claude/skills/caesar` (per #11) stays trackable.

## Blast radius / revertable
Blast radius: git's untracked-file listing only. No code, no behaviour. Fully revertable with `git revert`.