### PR TITLE
Caesar's skill scaffold, frozen scripts and junction install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/worktrees/
+.claude/caesar-runs/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
-﻿# Caesar
+# Caesar
 
 An orchestrator layer on top of the Wayfinder workflow. Raj talks to one session; Caesar drives the map's tickets, running AFK work itself and pulling the human in only for prototype and grilling tickets.
 
+## Install
+
+```powershell
+.\install.ps1
+```
+
+Junctions `~\.claude\skills\caesar` onto `skill\` in this repo. No admin needed, no
+restart needed — Claude Code loads a junctioned skill live. Idempotent; re-run it after
+moving the repo. `.\install.ps1 -Uninstall` removes the junction.
+
+Then, from inside whichever repo owns the map:
+
+```
+/caesar https://github.com/<owner>/<repo>/issues/<map-number>
+```
+
+## Layout
+
+| Path | What |
+|---|---|
+| `skill/SKILL.md` | The judgment layer — which ticket to take, when to interrupt, the merge gate |
+| `skill/scripts/frontier.ps1` | Frozen: one-GraphQL-call frontier sweep of a map |
+| `skill/scripts/spawn-ticket-agent.ps1` | Frozen: fire one headless ticket agent, worktree + deny list |
+| `skill/scripts/remove-worktree.ps1` | Frozen: fail-closed worktree teardown |
+| `install.ps1` | The junction install |
+| `docs/research/` | Prior-art and measurement write-ups |
+
+The three scripts are **frozen** because each is a command whose safety is a flag that
+improvisation can silently drop. Judgment stays prose; these do not.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,61 @@
+<#
+.SYNOPSIS
+  Installs Caesar as a global Claude Code skill by junctioning ~/.claude/skills/caesar
+  onto this repo's skill source. Idempotent and safe to re-run.
+
+.DESCRIPTION
+  A junction, not a copy: ~/.claude is not a git repo, so a copied Caesar would be
+  untracked and every edit would need the install re-run  -  guaranteed drift (issue #11).
+
+  Verified on Windows 11: New-Item -ItemType Junction needs no admin (unlike a symlink,
+  which needs elevation or Developer Mode), and Claude Code picks a junctioned skill up
+  live, with no restart.
+
+  Refuses to touch a real directory at the target. Re-points an existing junction.
+
+.EXAMPLE
+  pwsh -File .\install.ps1
+  pwsh -File .\install.ps1 -Uninstall
+#>
+[CmdletBinding()]
+param(
+    [string]$LinkPath = (Join-Path $env:USERPROFILE '.claude\skills\caesar'),
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+$source = Join-Path $PSScriptRoot 'skill'
+if (-not $Uninstall -and -not (Test-Path (Join-Path $source 'SKILL.md'))) {
+    throw "No SKILL.md at $source  -  run this from the Caesar repo root."
+}
+
+$existing = Get-Item -LiteralPath $LinkPath -Force -ErrorAction SilentlyContinue
+$isJunction = $existing -and $existing.LinkType -eq 'Junction'
+
+if ($Uninstall) {
+    if (-not $existing) { Write-Host "Not installed: $LinkPath"; return }
+    if (-not $isJunction) { throw "REFUSED: $LinkPath is a real directory, not our junction. Delete it yourself if you mean to." }
+    [System.IO.Directory]::Delete($LinkPath)
+    Write-Host "Uninstalled: removed junction $LinkPath"
+    return
+}
+
+if ($existing) {
+    if (-not $isJunction) {
+        throw "REFUSED: $LinkPath already exists as a real directory. Move or delete it, then re-run."
+    }
+    # .Target is an array on some PowerShell versions.
+    $target = @($existing.Target)[0]
+    if ($target -and (Resolve-Path $target).Path -eq (Resolve-Path $source).Path) {
+        Write-Host "Already installed: $LinkPath -> $source"
+        return
+    }
+    Write-Host "Re-pointing existing junction (was: $target)"
+    [System.IO.Directory]::Delete($LinkPath)
+}
+
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $LinkPath) | Out-Null
+New-Item -ItemType Junction -Path $LinkPath -Target $source | Out-Null
+Write-Host "Installed: $LinkPath -> $source"
+Write-Host "Claude Code loads junctioned skills live. Run /caesar <map-url> to check."

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: caesar
+description: Drive a Wayfinder map end to end. Use when the user invokes /caesar with a map issue URL, or asks to work, drive, resume or check on a Wayfinder map — Caesar sweeps the frontier, fires AFK tickets as headless agents, and grills the human only on the tickets that need one.
+---
+
+# Caesar
+
+You are Caesar. You drive **Wayfinder maps** — nothing else. You are not a general
+work supervisor; if the user wants one, that is a different effort.
+
+Raj hand-runs every ticket today: stop, spawn an agent, remember what is next, repeat.
+You remove that. He talks to one session — yours — and you work the frontier: resolving
+AFK tickets yourself via spawned agents, and interrupting him only for the ticket types
+that genuinely need a human.
+
+Read `C:\Users\rajdh\.claude\skills\wayfinder\SKILL.md` for the map format and ticket
+semantics. You carry the tracker operations yourself (below), so target repos need no
+tracker doc of their own.
+
+## Invocation and roles
+
+`/caesar <map-url>` from inside the repo the map belongs to. Infer `owner/repo` from
+the URL. Two roles:
+
+- **Primary.** Spawns ticket agents and owns the global concurrency cap. Assume primary
+  unless told otherwise.
+- **Grill-only** (`/caesar <map-url> grill-only`). HITL tickets only, spawns nothing.
+  Exists so several HITL tickets can be worked in parallel sessions without any cap
+  coordination — with four HITL tickets takeable at once, forcing them through one
+  session is a real regression.
+
+Only one primary at a time.
+
+## The loop
+
+1. **Sweep.** `scripts/frontier.ps1 -MapUrl <url>`. One GraphQL call, one rate-limit
+   point, every child ticket with its type, claim state and open blockers.
+2. **Fire the AFK work first.** Every unblocked AFK ticket (`research`, AFK `task`)
+   goes out as a spawned agent *before* you open a grill — up to the cap, queue the
+   rest. Do not park them until after the conversation; that wastes the whole grill.
+3. **Grill.** Take one HITL ticket (`grilling`, `prototype`, HITL `task`) and work it
+   with Raj in-session. There is no relay and no handoff: subagents cannot converse
+   with a human, so you *are* the channel.
+4. **Harvest.** As agents land, verify each against GitHub, append its gist to the map,
+   tear down its worktree.
+5. **Repeat** until the frontier is empty.
+
+Never resolve more than one HITL ticket per session. Research tickets are exempt.
+
+## Choosing what to work
+
+There is no scheduler. Read the frontiers, **name the map and ticket you are picking
+and why**, and let Raj override in a sentence. Judgment beats a priority field.
+
+Claim before you work: assign the ticket to Raj's GitHub login first, so a concurrent
+session skips it. An open, unassigned ticket is unclaimed.
+
+## Running an AFK ticket
+
+`scripts/spawn-ticket-agent.ps1` — one headless `claude -p` process per ticket, each in
+its own git worktree. The script carries the flag set and the deny list; do not compose
+that command by hand.
+
+The agent **posts its own resolution comment and closes its own ticket**, then prints a
+`GIST:` line. You read only the gist and append it to the map. This keeps your context
+cheap and, more importantly, makes verification real.
+
+**Never treat an exit code as evidence of work done.** A run that silently did nothing
+exits 0 with `is_error: false` and an empty `permission_denials`. Verify against the
+artifact: is the issue closed, does it carry a resolution comment.
+
+**Concurrency: 4 spawned agents, globally, across all maps.** Measured, not chosen —
+8 cores, 15.7 GB with ~2.3 GB free, agents at 150–400 MB each. It also bounds spend and
+blast radius. Per-ticket spend is capped by `-BudgetUsd` (default 2.0). Both are
+overridable per-map in the map's own **Notes** section.
+
+### Reporting mid-grill
+
+Default: **one gist line, then straight back to the grill question.** The gist, never
+the title — a title cannot be judged; the gist is the sentence that will represent that
+decision forever, so it is the right unit of review.
+
+Stop the grill only when: the resolution contradicts a locked decision, it drifts
+outside the destination, or the agent errored. **You are the smell test, not Raj** — you
+hold the whole map and are far better placed to catch a contradiction, which is the
+failure that actually hurts because it silently poisons every downstream ticket.
+
+## Build work and the merge gate
+
+You do decisions, AFK tasks, and full implementation. The rail is a branch, not a
+refusal: implementation lands as a PR, and `main` changes only on Raj's explicit word.
+
+You may press merge yourself — **never on inferred consent.** Approval-shaped language
+is not an instruction. Name the PR before you do it.
+
+`/implement` ends by committing to the current branch, creating no branch and opening no
+PR. Branch discipline is yours to impose around it.
+
+Every PR carries five things before you may ask for the word:
+
+1. What changed
+2. Why, with the ticket link
+3. **Proof it ran** — dogfooded on a real map, or on a throwaway map issue where the
+   change could loop or mangle live issues
+4. The 1–2 riskiest hunks, by `file:line`
+5. Blast radius, and whether it is revertable
+
+A PR whose evidence says *"not run"* escalates automatically to Raj's line-by-line read.
+Ready PRs **queue and land at a break in the grill** — interrupting a grill to ask for
+a merge is how a spot-check degrades into a rubber stamp.
+
+Post-merge, if Raj says revert: revert on the spot, then re-ticket the redo.
+
+## Worktrees
+
+Every spawned agent gets its own, always — `--worktree` inside the spawn script. Not
+per ticket type: the deciding factor is parallelism, and N processes in one checkout
+collide on `git checkout` no matter what they write.
+
+The agent renames off the machine-gibberish `worktree-<name>` onto a legible branch, so
+the PR is judgeable. Teardown is `scripts/remove-worktree.ps1`, which is **fail-closed**
+— it will not delete a worktree holding uncommitted or unpushed work.
+
+Report a leftover **once, with the resolution attached**: what happened to the ticket,
+that you have already handled it, where the remains are, and that he can say "bin it".
+A bare "there is a folder here" is unactionable and is a bug in you.
+
+## Holding several maps
+
+A map is yours only while its issue carries **`caesar:driving`**. Discovery is one
+command:
+
+```
+gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving
+```
+
+`--owner` is mandatory — a label-only search returns twenty strangers' public maps.
+
+**No state file.** GitHub reports which tickets are assigned and open; `git worktree
+list` reports what is still running. Both are already the truth, so a scratch file
+could only disagree with them.
+
+Withdrawing from a map is **drain, never kill**: running agents finish and post their
+artifacts, nothing new starts.
+
+## Writing to the map
+
+**You are the sole writer to the map body.** Ticket agents write only to their own
+tickets — that rule is carried in the spawn prompt, because no permission specifier can
+express "don't write to issue #1".
+
+GitHub issue writes are silently **last-write-wins** — a stale `If-Match` ETag returns a
+hard 400, not a 412, so there is no optimistic concurrency to lean on. Every map-body
+write is **read-verify-retry**: re-read, write, re-read to confirm, retry on mismatch.
+Parallel grill-only sessions make this load-bearing, not theoretical.
+
+## Register
+
+Raj's internal register is caveman mode — terse, no filler. Code, commits and PRs stay
+normal prose. He is a solo operator still learning GitHub, so never make him drive the
+tracker himself: report state in chat, and act on his sentence.
+
+## Not yet settled
+
+Deliberately absent, and tracked as open tickets on Caesar's own map:
+
+- **Agent failure handling** (#17) — errored, silently did nothing, stalled, half-done,
+  or coherently wrong. Until it resolves: verify against GitHub, and when a run fails,
+  leave the ticket open and unassigned so it returns to the frontier, keep the worktree,
+  and tell Raj once.
+- **What Raj reads to see where things stand** (#10) — the status view.
+- **Session startup and rehydration** — what you do on your first turn to rebuild the
+  picture, including a ticket assigned to Raj with no live process behind it.
+- **Charting new maps** — whether you may run `/wayfinder` in charting mode, or only
+  work existing maps. Assume only existing maps until decided.
+- **Veto after the fact** — Raj disagreeing with a decision already commented, closed
+  and written into the map.
+
+Out of scope for v1: away-mode and notifications (assume Raj is at the keyboard), and
+general non-Wayfinder work supervision.

--- a/skill/scripts/frontier.ps1
+++ b/skill/scripts/frontier.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+  Frozen frontier sweep. One GraphQL call (1 rate-limit point) returns every child
+  ticket of a Wayfinder map with its type, claim state and open blockers.
+
+.DESCRIPTION
+  Frozen because the correctness of the sweep depends on one easily-dropped detail:
+  GraphQL's blockedBy counts blockers of ANY state, disagreeing with REST's open-only
+  semantics (issue #3). A session composing this query from memory reads a ticket as
+  blocked when its blocker closed months ago, and the frontier silently shrinks.
+
+.EXAMPLE
+  .\frontier.ps1 -MapUrl https://github.com/Dhillvn/caesar/issues/1 -FrontierOnly
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MapUrl,
+    [switch]$FrontierOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($MapUrl -notmatch '^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)') {
+    throw "Not a GitHub issue URL: $MapUrl"
+}
+$owner = $Matches[1]
+$repo = $Matches[2]
+$num = [int]$Matches[3]
+
+$query = @'
+query($owner:String!,$repo:String!,$num:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$num){
+      number title
+      subIssues(first:100){
+        nodes{
+          number title state url
+          assignees(first:5){ nodes{ login } }
+          labels(first:10){ nodes{ name } }
+          blockedBy(first:50){ nodes{ number state } }
+        }
+      }
+    }
+  }
+}
+'@
+
+$raw = gh api graphql -f query=$query -F owner=$owner -F repo=$repo -F num=$num
+if ($LASTEXITCODE -ne 0) { throw "gh api graphql failed for $MapUrl" }
+
+$map = ($raw | ConvertFrom-Json).data.repository.issue
+if ($null -eq $map) { throw "No issue #$num in $owner/$repo" }
+
+# ponytail: 100 sub-issues is GitHub's hard cap on children per parent, so no paging.
+$rows = foreach ($t in $map.subIssues.nodes) {
+    # The one line this script exists for. See .DESCRIPTION.
+    $openBlockers = @($t.blockedBy.nodes | Where-Object { $_.state -eq 'OPEN' } | ForEach-Object { $_.number })
+    $assignees = @($t.assignees.nodes | ForEach-Object { $_.login })
+    $type = ($t.labels.nodes | Where-Object { $_.name -like 'wayfinder:*' } | Select-Object -First 1).name -replace '^wayfinder:', ''
+
+    if ($t.state -ne 'OPEN') { $status = 'closed' }
+    elseif ($openBlockers.Count -gt 0) { $status = 'blocked' }
+    elseif ($assignees.Count -gt 0) { $status = 'claimed' }
+    else { $status = 'frontier' }
+
+    [pscustomobject]@{
+        Number    = $t.number
+        Status    = $status
+        Type      = $type
+        ClaimedBy = ($assignees -join ',')
+        BlockedBy = ($openBlockers -join ',')
+        Title     = $t.title
+        Url       = $t.url
+    }
+}
+
+if ($FrontierOnly) { $rows = @($rows | Where-Object { $_.Status -eq 'frontier' }) }
+$rows | Sort-Object Number

--- a/skill/scripts/remove-worktree.ps1
+++ b/skill/scripts/remove-worktree.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+  Frozen worktree teardown. Fail-closed: refuses to delete a worktree holding
+  uncommitted changes or unpushed commits.
+
+.DESCRIPTION
+  Frozen because the dangerous version of this command is one word shorter than the
+  safe one. `git worktree remove --force` on a worktree an agent died inside destroys
+  the only copy of its work, and issue #8's rule is explicit: silent loss of work is
+  worse than a stale directory.
+
+  Returns an object; it never throws on a refusal. Removed=$false plus a Reason is the
+  expected outcome for a crashed agent, not an error. Report a leftover to Raj exactly
+  once, and with the ticket's resolution attached  -  "there is a folder here" is
+  unactionable and counts as a bug in Caesar (#8).
+
+.EXAMPLE
+  .\remove-worktree.ps1 -RepoPath C:\Users\rajdh\Projects\caesar -WorktreeName ticket-17-4821
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepoPath,
+    [Parameter(Mandatory = $true)][string]$WorktreeName
+)
+
+$ErrorActionPreference = 'Stop'
+
+$wt = Join-Path $RepoPath ".claude\worktrees\$WorktreeName"
+
+function New-Verdict($removed, $reason) {
+    [pscustomobject]@{
+        WorktreeName = $WorktreeName
+        WorktreePath = $wt
+        Removed      = $removed
+        Reason       = $reason
+    }
+}
+
+if (-not (Test-Path $wt)) { return New-Verdict $true 'already gone' }
+
+# Guard 1  -  uncommitted work, including untracked files an agent was mid-write on.
+$dirty = @(git -C $wt status --porcelain)
+if ($dirty.Count -gt 0) {
+    return New-Verdict $false "$($dirty.Count) uncommitted change(s)  -  kept"
+}
+
+# Guard 2  -  commits that exist nowhere else. No upstream counts as unpushed unless the
+# branch is identical to something already on the remote, so the default is to keep.
+$branch = (git -C $wt rev-parse --abbrev-ref HEAD).Trim()
+$unpushed = @(git -C $wt log --format='%h' HEAD --not --remotes)
+if ($unpushed.Count -gt 0) {
+    return New-Verdict $false "$($unpushed.Count) unpushed commit(s) on '$branch'  -  kept"
+}
+
+# Clean. `--worktree` creates the worktree locked, so the unlock is not optional:
+# `git worktree remove` fails outright on a locked worktree.
+#
+# PowerShell 5.1 turns a native command's stderr into a terminating ErrorRecord under
+# ErrorActionPreference = Stop, so the two commands allowed to fail harmlessly (an
+# already-unlocked worktree, an absent auto-branch) are run with it relaxed and are
+# judged on $LASTEXITCODE instead.
+$ErrorActionPreference = 'Continue'
+
+git -C $RepoPath worktree unlock $wt *> $null
+git -C $RepoPath worktree remove $wt *> $null
+if ($LASTEXITCODE -ne 0) { return New-Verdict $false 'git worktree remove failed  -  kept' }
+
+# Delete the throwaway auto-branch only. -d refuses an unmerged branch, which is the
+# same fail-closed posture as the guards above; the agent's real renamed branch lives
+# on the remote behind its PR and is not ours to bin.
+$autoBranch = "worktree-$WorktreeName"
+git -C $RepoPath branch -d $autoBranch *> $null
+
+New-Verdict $true 'clean  -  removed'

--- a/skill/scripts/spawn-ticket-agent.ps1
+++ b/skill/scripts/spawn-ticket-agent.ps1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+  Frozen spawn. Fires one headless `claude -p` ticket agent in its own git worktree,
+  permissive minus the deny list, capped by a dollar budget, and returns immediately.
+
+.DESCRIPTION
+  Frozen because this command's safety IS its flag set (issue #11). A session that
+  composes it from prose can drop --disallowedTools, and an unattended agent with no
+  one reading its output then has free rein on a machine with no sandboxing
+  (Claude Code has none on native Windows  -  issue #2).
+
+  Verified live on this repo before freezing:
+    - --disallowedTools "Bash(rm -rf:*)" is enforced from the CLI, and the blocked
+      call is reported in the result JSON's permission_denials.
+    - It stays enforced under --permission-mode bypassPermissions, which is what
+      makes "permissive minus a deny list" a single invocation with no settings.json.
+
+  The caller does NOT wait. Poll the result file, and verify the work against GitHub
+  (is the issue closed, does it carry a resolution comment)  -  never against the exit
+  code, which issue #15 proved is a liar: a run that silently did nothing exits 0.
+
+.EXAMPLE
+  .\spawn-ticket-agent.ps1 -RepoPath C:\Users\rajdh\Projects\caesar `
+      -TicketUrl https://github.com/Dhillvn/caesar/issues/17 -PromptFile .\prompt.txt
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$RepoPath,
+    [Parameter(Mandatory = $true)][string]$TicketUrl,
+    [Parameter(Mandatory = $true, ParameterSetName = 'Inline')][string]$Prompt,
+    [Parameter(Mandatory = $true, ParameterSetName = 'File')][string]$PromptFile,
+    [string]$WorktreeName,
+    [double]$BudgetUsd = 2.0
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($TicketUrl -notmatch '/issues/(\d+)') { throw "Not a GitHub issue URL: $TicketUrl" }
+$ticketNumber = $Matches[1]
+if (-not (Test-Path (Join-Path $RepoPath '.git'))) { throw "Not a git repo: $RepoPath" }
+if ($PromptFile) {
+    if (-not (Test-Path $PromptFile)) { throw "No prompt file at $PromptFile" }
+    $Prompt = Get-Content -Raw -LiteralPath $PromptFile
+}
+if (-not $WorktreeName) { $WorktreeName = "ticket-$ticketNumber-$(Get-Random -Maximum 9999)" }
+
+# The deny list (issue #7). Short by design: it covers only what escapes git's safety
+# net or crosses a locked boundary. The realistic threat is a confused agent, not a
+# malicious one, and a confused agent reaches for `rm -rf`, not an obfuscated variant.
+$denied = @(
+    # Merge boundary  -  only Caesar merges, and only on Raj's explicit word (#6, #16).
+    # The agent has no channel to receive that word, so this gate is structural.
+    'Bash(gh pr merge:*)'
+    'Bash(git merge:*)'
+    'Bash(git push origin main:*)'
+    'Bash(git push --force:*)'
+    'Bash(git push -f:*)'
+    'Bash(git push --force-with-lease:*)'
+    # Unrecoverable  -  past the point git can undo it.
+    'Bash(git reset --hard:*)'
+    'Bash(git clean -fdx:*)'
+    'Bash(rm -rf:*)'
+    'Bash(gh repo delete:*)'
+    'Bash(gh repo archive:*)'
+    'Bash(gh api --method DELETE:*)'
+    # Credentials.
+    'Bash(gh auth token:*)'
+    'Read(~/.ssh/**)'
+    'Read(**/.env)'
+)
+
+$logDir = Join-Path $RepoPath '.claude\caesar-runs'
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$resultFile = Join-Path $logDir "$WorktreeName-$stamp.json"
+$stderrFile = Join-Path $logDir "$WorktreeName-$stamp.err"
+$promptPath = Join-Path $logDir "$WorktreeName-$stamp.prompt.txt"
+
+# Carried in the prompt, not the permission layer: no permission specifier can express
+# "don't write to the map issue", and Caesar is sole writer to the map body (#5).
+$guardrail = @"
+You are a Wayfinder ticket agent working ticket $TicketUrl.
+
+Write ONLY to your own ticket ($TicketUrl) and to your own git branch. Never edit the
+map issue body, and never edit another ticket. You cannot merge anything; open a draft
+PR and stop.
+
+When you are done, post your resolution as a comment on your ticket and close the
+ticket yourself. Then print, as the last line of your reply, a single line starting
+with 'GIST: '  -  30 to 60 words stating the answer. That sentence is what will
+represent this decision on the map forever, so make it judgeable on its own.
+
+--- ticket instructions follow ---
+$Prompt
+"@
+
+# The prompt goes in on stdin, not as an argv element. It is multi-line, and
+# Start-Process flattens -ArgumentList into a single command line, so a prompt passed
+# as an argument gets shredded at its first newline ("error: unknown option").
+Set-Content -LiteralPath $promptPath -Value $guardrail -Encoding UTF8
+
+$claudeArgs = @(
+    '-p'
+    '--output-format', 'json'
+    '--worktree', $WorktreeName
+    '--permission-mode', 'bypassPermissions'
+    '--max-budget-usd', $BudgetUsd
+    '--disallowedTools'
+) + $denied
+# NOTE: --bare is banned (#7)  -  it forces API-key auth. Plain `claude -p` keeps
+# subscription auth, which is what the cost measurement in #15 reflects.
+
+# Every argument is quoted explicitly. Start-Process joins the array on spaces with no
+# quoting of its own, and deny specifiers like 'Bash(rm -rf:*)' contain a space - so
+# unquoted they split into two arguments and the rule silently stops matching. A deny
+# list that fails open is worse than no deny list, because it looks present.
+$cmdLine = ($claudeArgs | ForEach-Object { '"' + ($_ -replace '"', '\"') + '"' }) -join ' '
+
+$proc = Start-Process -FilePath 'claude' -ArgumentList $cmdLine `
+    -WorkingDirectory $RepoPath -WindowStyle Hidden -PassThru `
+    -RedirectStandardInput $promptPath `
+    -RedirectStandardOutput $resultFile -RedirectStandardError $stderrFile
+
+[pscustomobject]@{
+    Ticket       = $TicketUrl
+    WorktreeName = $WorktreeName
+    WorktreePath = Join-Path $RepoPath ".claude\worktrees\$WorktreeName"
+    ProcessId    = $proc.Id
+    ResultFile   = $resultFile
+    StderrFile   = $stderrFile
+    PromptFile   = $promptPath
+    BudgetUsd    = $BudgetUsd
+}


### PR DESCRIPTION
Resolves #19. Shape settled in #11; the scripts carry decisions from #3, #7 and #8.

## 1. What changed

| File | What |
|---|---|
| `skill/SKILL.md` | The judgment layer as prose — the loop, ticket choice, the merge gate, mid-grill reporting, the concurrency cap, read-verify-retry on map writes |
| `skill/scripts/frontier.ps1` | Frozen. One GraphQL call per sweep; classifies every child ticket as `frontier` / `claimed` / `blocked` / `closed` |
| `skill/scripts/spawn-ticket-agent.ps1` | Frozen. One headless `claude -p` per ticket, own worktree, permissive-minus-deny-list, budget-capped, non-blocking |
| `skill/scripts/remove-worktree.ps1` | Frozen. Fail-closed teardown |
| `install.ps1` | Idempotent directory junction; refuses to clobber a real directory |
| `.gitignore` | Adds `.claude/caesar-runs/` (spawn logs, result JSON and prompt files) |
| `README.md` | Install and layout |

`SKILL.md` deliberately names what is **not** settled — #17, #10, and the map's fog items — with a conservative interim rule for agent failure, rather than quietly inventing answers those tickets exist to make.

## 2. Why

#19: make Caesar exist on disk so later tickets dogfood a real skill instead of a plan.

## 3. Proof it ran

Dogfooded on this repo. A throwaway issue (#21, now closed) was used as the spawn target so nothing on the live map could be mangled.

- **`frontier.ps1`** — swept map #1, returned all 15 children correctly classified: #17 `frontier`, #10 and #19 `claimed`, the rest `closed`.
- **`install.ps1`** — created the junction, reported `Already installed` on a second run, and a **fresh headless session loaded the skill through the junction** and read back `# Caesar` from `SKILL.md`. That is #19's "done when".
- **`spawn-ticket-agent.ps1`** — fired a real agent at #21. It landed in its own worktree on `worktree-ticket-21-2987`, its `rm -rf` probe was **denied at the permission layer**, and it posted its resolution comment, closed #21 itself, and printed its `GIST:` line. `is_error: false`, one recorded `permission_denial`, $0.27.
- **`remove-worktree.ps1`** — all four paths: dirty → kept, unpushed commit → kept, clean → removed, already gone → idempotent. Then used for real on the agent's worktree. No leftover worktrees, no orphan `worktree-*` branches.

Three things were verified live rather than assumed, two of which were bugs this testing caught:

1. **#7's open build-time check is closed.** `--disallowedTools "Bash(rm -rf:*)"` **is** accepted and enforced from the CLI, and stays enforced under `--permission-mode bypassPermissions`. So "permissive minus a deny list" is one invocation — no `settings.json` needed.
2. **`Start-Process` splits `Bash(rm -rf:*)` on its internal space.** Unquoted, roughly half the deny list silently stopped matching while still *appearing* present. Arguments are now quoted explicitly.
3. **A multi-line prompt cannot go in argv.** `Start-Process` flattens `-ArgumentList` into one command line; the first run died with `error: unknown option '--- This'`. The prompt now goes in on stdin.

## 4. Riskiest hunks

- `skill/scripts/spawn-ticket-agent.ps1:107` — the explicit-quoting line. This is the one place where a silent failure is unsafe rather than merely broken: a deny list that fails open looks identical to one that works. The `rm -rf` probe in the end-to-end run is the check that it holds, and it should stay a check on every future change to this script.
- `skill/scripts/remove-worktree.ps1:50` — the unpushed-commits guard, `git log HEAD --not --remotes`. Get this wrong and the script deletes an agent's only copy of its work. (The first version used `--branches=HEAD`, which is a branch *glob* and matched nothing — it would have reported every worktree as safe to delete. Caught and fixed before commit; the four-path test above covers the fixed version.)

## 5. Blast radius, revertable?

Additive: five new files plus one `.gitignore` line and a README section. Nothing existing changes behaviour. Fully revertable by reverting the commit — and, because the install is a junction rather than a copy, reverting the merge also reverts what `~/.claude/skills/caesar` serves, with `install.ps1 -Uninstall` to detach entirely.

**One thing to do after merge:** the junction currently points into this PR's worktree. Re-run `.\install.ps1` from the repo root to re-point it at `main` (it detects and re-points an existing junction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
