### PR TITLE
Fix install.ps1 throwing on a dangling junction

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -45,13 +45,19 @@ if ($existing) {
     if (-not $isJunction) {
         throw "REFUSED: $LinkPath already exists as a real directory. Move or delete it, then re-run."
     }
-    # .Target is an array on some PowerShell versions.
+    # .Target is an array on some PowerShell versions. Resolve it with -ErrorAction
+    # SilentlyContinue: a junction whose target has been deleted still exists and still
+    # reports a Target, but Resolve-Path throws on it. That dangling state is the normal
+    # post-merge case - tearing down the worktree the junction pointed at produces it -
+    # so it must re-point, not blow up.
     $target = @($existing.Target)[0]
-    if ($target -and (Resolve-Path $target).Path -eq (Resolve-Path $source).Path) {
+    $targetResolved = if ($target) { (Resolve-Path $target -ErrorAction SilentlyContinue).Path } else { $null }
+    if ($targetResolved -and $targetResolved -eq (Resolve-Path $source).Path) {
         Write-Host "Already installed: $LinkPath -> $source"
         return
     }
-    Write-Host "Re-pointing existing junction (was: $target)"
+    if ($targetResolved) { Write-Host "Re-pointing existing junction (was: $target)" }
+    else { Write-Host "Re-pointing dangling junction (target gone: $target)" }
     [System.IO.Directory]::Delete($LinkPath)
 }
 


### PR DESCRIPTION
Follow-up to #22, found by running its own post-merge instruction.

## 1. What changed

`install.ps1` — resolve the existing junction's target with `-ErrorAction SilentlyContinue`, and treat an unresolvable target as "doesn't match, re-point" rather than letting `Resolve-Path` throw. Adds a distinct message for the dangling case. One hunk.

## 2. Why

A junction whose target directory has been deleted still exists and still reports a `Target`, but `Resolve-Path` throws `PathNotFound` on it. So the re-run died instead of re-pointing:

```
Resolve-Path : Cannot find path '...\.claude\worktrees\build-skill-scaffold\skill' because it does not exist.
At install.ps1:50
```

This is not an edge case — it is the **normal post-merge path**, and the exact one #22's own PR body instructs. Tearing down the worktree the junction pointed at is what deletes the old target, so anyone following the instruction hits it every time.

## 3. Proof it ran

Reproduced the failure on a throwaway junction (create junction → delete its target), then ran the fixed script against it:

- **dangling target** → `Re-pointing dangling junction (target gone: ...)`, then re-pointed correctly. Previously: threw.
- **second run** → `Already installed`. Still idempotent.
- **real directory at the target** → still `REFUSED`, unchanged.
- The live `~\.claude\skills\caesar` junction was re-checked afterwards and still points at `C:\Users\rajdh\Projects\caesar\skill`.

## 4. Riskiest hunk

`install.ps1:50` — the resolve-and-compare. The failure mode to avoid is over-correcting into silence: if the comparison were made lenient rather than the *resolution*, a junction pointing somewhere wrong would report `Already installed` and never re-point. The equality check is deliberately still on the resolved path, and `$null -eq $targetResolved` falls through to re-point rather than to "already installed" — fail toward re-pointing, never toward a false all-clear.

## 5. Blast radius, revertable?

One file, one hunk, install-time only. Nothing at runtime touches it. Reverting the commit fully restores prior behaviour; the junction on disk is already correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
