### PR TITLE
Add the status view renderer (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Then, from inside whichever repo owns the map:
 | `skill/scripts/frontier.ps1` | Frozen: one-GraphQL-call frontier sweep of a map |
 | `skill/scripts/spawn-ticket-agent.ps1` | Frozen: fire one headless ticket agent, worktree + deny list |
 | `skill/scripts/remove-worktree.ps1` | Frozen: fail-closed worktree teardown |
+| `skill/scripts/status.ps1` | The status view — renders over the sweep, no query of its own |
 | `install.ps1` | The junction install |
 | `docs/research/` | Prior-art and measurement write-ups |
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -85,6 +85,20 @@ outside the destination, or the agent errored. **You are the smell test, not Raj
 hold the whole map and are far better placed to catch a contradiction, which is the
 failure that actually hurts because it silently poisons every downstream ticket.
 
+## Showing Raj where things stand
+
+Whenever he asks — "where are we", "what's left", "status" — run
+`scripts/status.ps1 -MapUrl <url> [<url> ...]` and show the table. That is the whole
+answer; there is no dashboard and no file on Drive, and he should never need GitHub's
+web UI.
+
+Six facts per open ticket: number, title, type, **Who** (You / Caesar), **State**
+(Blocked → Queued → Ongoing), and blockers when blocked. Rows sort by what needs him.
+
+A `wayfinder:task` counts as yours unless you stamp **`caesar:hitl`** on it — so stamp
+it at the moment you open a task that needs his hands, not later. `wayfinder:research`
+is always yours; `grilling` and `prototype` are always his.
+
 ## Build work and the merge gate
 
 You do decisions, AFK tasks, and full implementation. The rail is a branch, not a
@@ -168,7 +182,6 @@ Deliberately absent, and tracked as open tickets on Caesar's own map:
   or coherently wrong. Until it resolves: verify against GitHub, and when a run fails,
   leave the ticket open and unassigned so it returns to the frontier, keep the worktree,
   and tell Raj once.
-- **What Raj reads to see where things stand** (#10) — the status view.
 - **Session startup and rehydration** — what you do on your first turn to rebuild the
   picture, including a ticket assigned to Raj with no live process behind it.
 - **Charting new maps** — whether you may run `/wayfinder` in charting mode, or only

--- a/skill/scripts/frontier.ps1
+++ b/skill/scripts/frontier.ps1
@@ -34,7 +34,7 @@ query($owner:String!,$repo:String!,$num:Int!){
       number title
       subIssues(first:100){
         nodes{
-          number title state url
+          number title state url closedAt
           assignees(first:5){ nodes{ login } }
           labels(first:10){ nodes{ name } }
           blockedBy(first:50){ nodes{ number state } }
@@ -71,6 +71,10 @@ $rows = foreach ($t in $map.subIssues.nodes) {
         BlockedBy = ($openBlockers -join ',')
         Title     = $t.title
         Url       = $t.url
+        # For the status view (#24): who owns it, and what was decided last.
+        Hitl      = ($t.labels.nodes.name -contains 'caesar:hitl')
+        ClosedAt  = $t.closedAt
+        MapTitle  = $map.title
     }
 }
 

--- a/skill/scripts/status.ps1
+++ b/skill/scripts/status.ps1
@@ -1,0 +1,135 @@
+<#
+.SYNOPSIS
+  The status view: what Raj reads to see where things stand (issue #24, design #10).
+
+.DESCRIPTION
+  Renders over frontier.ps1 — no GraphQL of its own, so the blockedBy open-only filter
+  stays in exactly one place. Six facts per open ticket: number, title, Wayfinder type,
+  who acts, state, and blockers when blocked. Rows sort by what needs Raj first.
+
+.EXAMPLE
+  .\status.ps1 -MapUrl https://github.com/Dhillvn/caesar/issues/1
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string[]]$MapUrl,
+    [int]$Cap = 4
+)
+
+$ErrorActionPreference = 'Stop'
+
+$W = [ordered]@{ Num = 4; Who = 6; Ticket = 50; State = 13; Type = 9 }
+
+function Format-Cell([string]$Text, [int]$Width) {
+    if ($Text.Length -gt $Width) { $Text = $Text.Substring(0, $Width - 1) + [char]0x2026 }
+    $Text.PadRight($Width)
+}
+
+function Format-Row($Num, $Who, $Ticket, $State, $Type) {
+    '{0} {1} {0} {2} {0} {3} {0} {4} {0} {5} {0}' -f [char]0x2502,
+        (Format-Cell $Num $W.Num), (Format-Cell $Who $W.Who), (Format-Cell $Ticket $W.Ticket),
+        (Format-Cell $State $W.State), (Format-Cell $Type $W.Type)
+}
+
+function Format-Bar([char]$L, [char]$M, [char]$R) {
+    $segments = @($W.Values | ForEach-Object { [string][char]0x2500 * ($_ + 2) })
+    [string]$L + ($segments -join [string]$M) + [string]$R
+}
+
+# Wayfinder: research is always Caesar's, grilling and prototype always Raj's, and a
+# task is Caesar's unless he stamps `caesar:hitl` on it ("the agent drives it alone
+# where it can"). Anything unlabelled is Raj's — an unowned ticket should surface.
+function Get-Who($Row) {
+    if ($Row.Type -eq 'research') { return 'Caesar' }
+    if ($Row.Type -eq 'task' -and -not $Row.Hitl) { return 'Caesar' }
+    'You'
+}
+
+# what needs you, then what is moving, then what is next, then what is stuck
+function Get-Rank($Who, $State) {
+    switch ("$Who/$State") {
+        'You/Queued'     { 0 }
+        'You/Ongoing'    { 1 }
+        'Caesar/Ongoing' { 2 }
+        'Caesar/Queued'  { 3 }
+        default          { 4 }
+    }
+}
+
+function Split-Wrap([string]$Text, [int]$Width) {
+    $lines = @()
+    foreach ($word in ($Text -split ' +')) {
+        if ($lines.Count -eq 0) { $lines = @($word) }
+        elseif (($lines[-1] + ' ' + $word).Length -le $Width) { $lines[-1] += ' ' + $word }
+        else { $lines += $word }
+    }
+    # ponytail: a single word wider than the cell is left to Format-Cell to truncate.
+    $lines
+}
+
+$sweepScript = Join-Path $PSScriptRoot 'frontier.ps1'
+$slots = 0
+$repos = @()
+
+Write-Output ("CAESAR - {0}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm'))
+
+foreach ($url in $MapUrl) {
+    if ($url -notmatch '^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)') {
+        throw "Not a GitHub issue URL: $url"
+    }
+    $repos += "$($Matches[1])/$($Matches[2])"
+    $mapNum = $Matches[3]
+
+    $rows = @(& $sweepScript -MapUrl $url)
+    $done = @($rows | Where-Object { $_.Status -eq 'closed' } | Sort-Object ClosedAt)
+    $open = @($rows | Where-Object { $_.Status -ne 'closed' } | ForEach-Object {
+        $state = switch ($_.Status) { 'blocked' { 'Blocked' } 'claimed' { 'Ongoing' } default { 'Queued' } }
+        $who = Get-Who $_
+        [pscustomobject]@{
+            Number = $_.Number; Title = $_.Title; Type = $_.Type
+            Who = $who; State = $state; BlockedBy = $_.BlockedBy
+            Rank = (Get-Rank $who $state)
+        }
+    } | Sort-Object Rank, Number)
+
+    $slots += @($open | Where-Object { $_.Who -eq 'Caesar' -and $_.State -eq 'Ongoing' }).Count
+
+    $headline = "{0} decided {1} {2} open" -f $done.Count, [char]0x00B7, $open.Count
+    if ($done.Count -gt 0) { $headline += " {0} last was #{1} {2}" -f [char]0x00B7, $done[-1].Number, $done[-1].Title }
+
+    Write-Output ''
+    Write-Output ("MAP #{0}  {1}" -f $mapNum, $rows[0].MapTitle)
+    Write-Output $headline
+    Write-Output ''
+    Write-Output (Format-Bar ([char]0x250C) ([char]0x252C) ([char]0x2510))
+    Write-Output (Format-Row '#' 'Who' 'Ticket' 'State' 'Type')
+    Write-Output (Format-Bar ([char]0x251C) ([char]0x253C) ([char]0x2524))
+
+    if ($open.Count -eq 0) {
+        Write-Output (Format-Row '' '' 'nothing open - map is done' '' '')
+    }
+    foreach ($t in $open) {
+        $state = $t.State
+        if ($t.BlockedBy) { $state += ' ' + (($t.BlockedBy -split ',' | ForEach-Object { "#$_" }) -join ',') }
+        $wrapped = @(Split-Wrap $t.Title $W.Ticket)
+        Write-Output (Format-Row "#$($t.Number)" $t.Who $wrapped[0] $state $t.Type)
+        foreach ($cont in @($wrapped | Select-Object -Skip 1)) {
+            Write-Output (Format-Row '' '' ("  " + $cont) '' '')
+        }
+    }
+    Write-Output (Format-Bar ([char]0x2514) ([char]0x2534) ([char]0x2518))
+}
+
+Write-Output ''
+Write-Output "Agent slots: $slots of $Cap in use"
+Write-Output 'Waiting on your word:'
+# ponytail: formatted here rather than with --jq; a jq expression containing spaces is
+# mangled on the way through PowerShell's native-argument handling.
+$prs = foreach ($r in ($repos | Select-Object -Unique)) {
+    $json = gh pr list --repo $r --state open --json number,title,isDraft
+    if ($LASTEXITCODE -ne 0) { throw "gh pr list failed for $r" }
+    foreach ($pr in ($json | ConvertFrom-Json)) {
+        "  PR #{0}  {1}{2}" -f $pr.number, $pr.title, $(if ($pr.isDraft) { '  (draft)' } else { '' })
+    }
+}
+if ($prs) { $prs } else { Write-Output '  nothing - no open PRs' }


### PR DESCRIPTION
Builds #24 — the status view — from the model and design settled in #10.

## What changed

- **`skill/scripts/status.ps1`** (new). Bordered table, columns `# · Who · Ticket · State · Type`, header row, titles wrapped inside the cell. Rows sort Raj-queued → Raj-ongoing → Caesar-ongoing → Caesar-queued → blocked. Per map: title, `N decided · M open`, last decided. Once globally: agent slots against the cap of 4 (#9), and open PRs awaiting the merge word (#16). Takes several `-MapUrl` values.
- **`skill/scripts/frontier.ps1`**: three additive fields the renderer needs — `Hitl`, `ClosedAt`, `MapTitle`. The frozen open-only `blockedBy` filter is untouched, and existing callers are unaffected.
- **`caesar:hitl` label** created on this repo. A `wayfinder:task` is Caesar's unless stamped with it; `wayfinder:research` is always Caesar's, `grilling` and `prototype` always Raj's.
- **`skill/SKILL.md`**: new "Showing Raj where things stand" section, instruction to stamp `caesar:hitl` when opening a task needing Raj's hands, and #10 dropped from *Not yet settled*.
- **`README.md`**: script table row.

## Why

Ticket: #24. Design: #10 — six facts per open ticket, 2×3 with Blocked as the rung below Queued, borders and a header row after three borderless layouts died on "difficult to read". The reference `prototype-status-view.sh` on `proto/status-view` was ported; its `is_afk` and bucket logic carried over, its bash and its own GraphQL query did not.

## Proof it ran

Dogfooded on this live map (#1) through both the repo path and the installed junction (`~/.claude/skills/caesar/scripts/status.ps1`), confirming the install needs no restart.

The two paths no live ticket exercised were tested for real and reverted: `caesar:hitl` was stamped on #24 (Who flipped `Caesar` → `You`) and a `blocked_by` edge on #17 was added (State rendered `Blocked #17`, and the agent-slot count correctly dropped to 0). Both were then removed and the sweep re-read to confirm `Hitl: False` and `BlockedBy` empty.

## Riskiest hunks

- `skill/scripts/status.ps1:22` — the `[ordered]` width table. A plain hashtable enumerates in arbitrary order, so `Format-Bar` would emit column rules that do not line up with the cells. Caught before commit; ordered is load-bearing, not stylistic.
- `skill/scripts/status.ps1:139` — PR listing formats in PowerShell rather than with `--jq`. A jq expression containing spaces is mangled passing through PowerShell native-argument handling; the first run failed here with `unknown arguments ["PR" ...]`.

## Blast radius

Read-only against GitHub — it queries and renders, and writes nothing. The one shared file is `frontier.ps1`, additive only. Fully revertable: revert the commit and delete the `caesar:hitl` label.
