### PR TITLE
Build failure triage: inspect-run script, needs-raj label, SKILL.md rules

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -85,6 +85,73 @@ outside the destination, or the agent errored. **You are the smell test, not Raj
 hold the whole map and are far better placed to catch a contradiction, which is the
 failure that actually hurts because it silently poisons every downstream ticket.
 
+## When a spawned agent fails
+
+**Retry a bad roll, flag a wall. One retry maximum, ever** — then flag regardless of
+class. There is no per-failure-mode policy table to apply: read the evidence and ask
+whether a re-fire could plausibly come out differently. If it could, re-fire once. If
+the same run would hit the same thing again, stop and hand it over.
+
+Look at it with `scripts/inspect-run.ps1` — pipe the spawn result straight in, or pass
+`-ResultFile` alone from a later session. It prints liveness, heartbeat, artifact state,
+the result JSON fields, and the stderr/transcript tails, and **returns no verdict**. The
+call is yours, here:
+
+| What you see | What you do |
+|---|---|
+| **Transient error** — `is_error: true`, stderr shows network / 5xx / rate limit | **Retry** |
+| **Budget exhausted** — cost at cap, no artifact | **Flag.** Raising the cap or splitting the ticket is Raj's call |
+| **Silent do-nothing** — exit 0, `is_error: false`, ticket open, no comment | **Retry**, prompt sharpened to name the missing artifact |
+| **Half-done** — comment but not closed, or closed with no comment | **Neither.** Finish the mechanical remainder yourself, no spawn. Flag only if the *work* is partial rather than the bookkeeping |
+| **Wedged** — killed after the heartbeat flatlined | **Triage on the tails.** Died mid-API-call → bad roll → retry. Looping the same action → wall → flag. Never really started (auth, bad path) → wall → flag |
+| **Coherently wrong** — artifact complete, answer collides with a prior decision | **Reopen, comment what it collides with, flag. Never retry** |
+
+Wrong never retries because new information may legitimately change Raj's mind — he
+might take the new answer or hold the old one, and you cannot know which. So it goes
+back to him with the collision named, never re-rolled and never resolved on your own
+judgment. The gist does not reach the map either way; you append only after verifying.
+
+**A non-empty `permission_denials` is not a failure signal.** A real successful run on
+disk carries one. Denials count only when no artifact landed.
+
+### The timer: look, do not kill
+
+**At 30 minutes you look; you do not kill.** Read the heartbeat: still moving → the
+ticket is genuinely long, let it run and re-check in 15. Not moving → wedged, kill by
+PID and triage on the tails. A hard kill at the clock bins legitimately slow work, and
+`--max-budget-usd` already bounds a runaway. Both intervals are overridable per-map in
+the map's **Notes**.
+
+A wedge is not automatically a flag — a dropped connection is a bad roll, a loop is a
+wall, and the table above already tells them apart.
+
+### Retry mechanics
+
+**Fresh spawn, fresh worktree**, prompt naming what the last attempt left behind ("a
+previous run pushed branch X — continue from it"). Never `--resume`: it carries the
+failed context forward, so an agent that talked instead of acting resumes talking.
+
+**The attempt count is a comment on the ticket** ("attempt 2 of 2"), not the run logs —
+`.claude/caesar-runs/` is gitignored machine-bound scratch that does not exist for a
+grill-only session on another checkout. GitHub is the truth.
+
+### Flagging: `caesar:needs-raj`
+
+A flagged ticket carries **`caesar:needs-raj`**, **stays assigned**, and gets a comment
+saying why you stopped. Label so the sweep sees it, comment so Raj can read it,
+assignment so it is off the frontier. `frontier.ps1` reports it as `flagged` and
+`status.ps1` renders it **Needs you**, above everything else.
+
+Never leave a failed ticket open and unassigned — that hands it back to the next
+session, which re-fires it, defeating the retry ceiling silently.
+
+The label is per ticket and is not only for failures: it marks **any AFK ticket you have
+stopped on**, including one that finished with an answer you will not accept alone. HITL
+tickets never carry it — Raj is already in the room.
+
+Retries fire **silently**. Flags **queue and surface at a break in the grill**, one line
+each — same as ready PRs, and for the same reason.
+
 ## Showing Raj where things stand
 
 Whenever he asks — "where are we", "what's left", "status" — run
@@ -178,10 +245,6 @@ tracker himself: report state in chat, and act on his sentence.
 
 Deliberately absent, and tracked as open tickets on Caesar's own map:
 
-- **Agent failure handling** (#17) — errored, silently did nothing, stalled, half-done,
-  or coherently wrong. Until it resolves: verify against GitHub, and when a run fails,
-  leave the ticket open and unassigned so it returns to the frontier, keep the worktree,
-  and tell Raj once.
 - **Session startup and rehydration** — what you do on your first turn to rebuild the
   picture, including a ticket assigned to Raj with no live process behind it.
 - **Charting new maps** — whether you may run `/wayfinder` in charting mode, or only

--- a/skill/scripts/frontier.ps1
+++ b/skill/scripts/frontier.ps1
@@ -56,10 +56,15 @@ $rows = foreach ($t in $map.subIssues.nodes) {
     # The one line this script exists for. See .DESCRIPTION.
     $openBlockers = @($t.blockedBy.nodes | Where-Object { $_.state -eq 'OPEN' } | ForEach-Object { $_.number })
     $assignees = @($t.assignees.nodes | ForEach-Object { $_.login })
+    $labels = @($t.labels.nodes | ForEach-Object { $_.name })
     $type = ($t.labels.nodes | Where-Object { $_.name -like 'wayfinder:*' } | Select-Object -First 1).name -replace '^wayfinder:', ''
 
     if ($t.state -ne 'OPEN') { $status = 'closed' }
     elseif ($openBlockers.Count -gt 0) { $status = 'blocked' }
+    # Caesar stopped on it (#17). Ahead of `claimed` so the flag survives an assignment
+    # being lost: without this the sweep hands every failure straight back to the next
+    # session, which re-fires it, silently defeating the one-retry ceiling.
+    elseif ($labels -contains 'caesar:needs-raj') { $status = 'flagged' }
     elseif ($assignees.Count -gt 0) { $status = 'claimed' }
     else { $status = 'frontier' }
 

--- a/skill/scripts/inspect-run.ps1
+++ b/skill/scripts/inspect-run.ps1
@@ -1,0 +1,166 @@
+<#
+.SYNOPSIS
+  Frozen failure triage. Prints the facts a failed or suspect ticket run left behind,
+  and returns NO verdict (issue #17).
+
+.DESCRIPTION
+  Frozen for the same reason as the sweep and the spawn: the fragile part is reading
+  the right fields, not making the call. Reading a result JSON by hand during #17's
+  grilling produced a wrong rule inside five minutes - a non-empty permission_denials
+  is not a failure signal, and a real successful run on disk carries one.
+
+  The judgment - retry a bad roll, flag a wall, one retry maximum - is prose in
+  SKILL.md. Nothing here classifies anything.
+
+  Takes the object spawn-ticket-agent.ps1 returns, so it pipes straight from it:
+    .\spawn-ticket-agent.ps1 ... | .\inspect-run.ps1
+  A later session that no longer holds that object passes -ResultFile alone; liveness
+  is then unknown and everything else is still recoverable from disk and GitHub.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][string]$ResultFile,
+    [Parameter(ValueFromPipelineByPropertyName = $true)][int]$ProcessId,
+    [Parameter(ValueFromPipelineByPropertyName = $true)][string]$Ticket,
+    [Parameter(ValueFromPipelineByPropertyName = $true)][string]$WorktreePath,
+    [Parameter(ValueFromPipelineByPropertyName = $true)][string]$StderrFile,
+    [Parameter(ValueFromPipelineByPropertyName = $true)][double]$BudgetUsd = 2.0,
+    [int]$TailLines = 6
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Section([string]$Name) { Write-Output ''; Write-Output $Name }
+function Fact([string]$Text) { Write-Output "  $Text" }
+function Ago([datetime]$When) {
+    $s = [int]((Get-Date) - $When).TotalSeconds
+    if ($s -lt 90) { "${s}s ago" } elseif ($s -lt 5400) { "$([int]($s / 60))m ago" } else { "$([math]::Round($s / 3600, 1))h ago" }
+}
+function Clip([string]$Text, [int]$Max = 200) {
+    $Text = ($Text -replace '\s+', ' ').Trim()
+    if ($Text.Length -gt $Max) { $Text.Substring(0, $Max) + [char]0x2026 } else { $Text }
+}
+
+# --- locate everything from the one path we are guaranteed ---------------------------
+# Combine against $PWD, not GetFullPath alone: .NET resolves a relative path against the
+# *process* working directory, which is not PowerShell's location, so a run inspected
+# from a `cd`-ed session silently reported on a path in a different repo entirely.
+$ResultFile = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($PWD.Path, $ResultFile))
+$logDir = Split-Path -Parent $ResultFile
+$base = [System.IO.Path]::GetFileNameWithoutExtension($ResultFile)
+# spawn names files <worktree>-yyyyMMdd-HHmmss.json, so the stamp strips deterministically
+$worktreeName = $base -replace '-\d{8}-\d{6}$', ''
+if (-not $StderrFile) { $StderrFile = Join-Path $logDir "$base.err" }
+$promptFile = Join-Path $logDir "$base.prompt.txt"
+
+if (-not $WorktreePath) {
+    $repoPath = Split-Path -Parent (Split-Path -Parent $logDir)   # <repo>\.claude\caesar-runs
+    $WorktreePath = Join-Path $repoPath ".claude\worktrees\$worktreeName"
+}
+if (-not $Ticket -and (Test-Path $promptFile)) {
+    # anchored on the url shape, not \S+, so the sentence's full stop is not swallowed
+    if ((Get-Content -Raw -LiteralPath $promptFile) -match 'working ticket (\S+/issues/\d+)') { $Ticket = $Matches[1] }
+}
+
+Write-Output ("RUN  {0}" -f $worktreeName)
+Fact "result   $ResultFile"
+Fact "worktree $WorktreePath"
+Fact "ticket   $(if ($Ticket) { $Ticket } else { '(unknown - no prompt file)' })"
+
+# --- liveness ------------------------------------------------------------------------
+Section 'LIVENESS'
+if (-not $ProcessId) {
+    Fact 'pid not supplied - liveness unknown, judge on heartbeat and artifact'
+} else {
+    $proc = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+    if (-not $proc) {
+        Fact "pid $ProcessId  DEAD"
+    } elseif ($proc.ProcessName -notmatch 'claude|node') {
+        # pids are recycled; a live pid owned by something else is not our run
+        Fact "pid $ProcessId  ALIVE but is '$($proc.ProcessName)' - pid reused, our run is DEAD"
+    } else {
+        Fact "pid $ProcessId  ALIVE ($($proc.ProcessName), started $($proc.StartTime), $([math]::Round($proc.WorkingSet64 / 1MB))MB)"
+    }
+}
+
+# --- heartbeat -----------------------------------------------------------------------
+# The only progress signal there is: `claude -p` writes its result JSON at the very end,
+# but the transcript .jsonl mtime advances while the agent works.
+Section 'HEARTBEAT'
+$dashed = $WorktreePath -replace '[:\\/.]', '-'
+$transcriptDir = Join-Path "$env:USERPROFILE\.claude\projects" $dashed
+$transcript = $null
+if (Test-Path $transcriptDir) {
+    $transcript = Get-ChildItem $transcriptDir -Filter *.jsonl -File | Sort-Object LastWriteTime | Select-Object -Last 1
+}
+if ($transcript) {
+    Fact "transcript $($transcript.Name)  ($([math]::Round($transcript.Length / 1KB))KB)"
+    Fact "last write $($transcript.LastWriteTime)  ($(Ago $transcript.LastWriteTime))"
+} elseif (Test-Path $transcriptDir) {
+    Fact "$transcriptDir exists but holds no .jsonl - the session never wrote a turn"
+} else {
+    Fact "no transcript dir at $transcriptDir - the run may never have started"
+}
+
+# --- artifact state, from GitHub -----------------------------------------------------
+Section 'ARTIFACT (GitHub - the only real evidence of work done)'
+if ($Ticket -match '^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)') {
+    $json = gh issue view $Matches[3] --repo "$($Matches[1])/$($Matches[2])" --json state,comments,assignees,labels
+    if ($LASTEXITCODE -ne 0) {
+        Fact 'gh issue view failed - could not read the ticket'
+    } else {
+        $issue = $json | ConvertFrom-Json
+        Fact "state $($issue.state)   assignees: $(($issue.assignees.login -join ',')) $(if (-not $issue.assignees) { '(none)' })"
+        Fact "labels $(($issue.labels.name -join ', '))"
+        if ($issue.comments.Count -eq 0) {
+            Fact 'comments 0 - no resolution comment'
+        } else {
+            Fact "comments $($issue.comments.Count), last by $($issue.comments[-1].author.login) at $($issue.comments[-1].createdAt):"
+            Fact "  `"$(Clip $issue.comments[-1].body)`""
+        }
+    }
+} else {
+    Fact 'no ticket url - cannot read artifact state'
+}
+
+# --- result json ---------------------------------------------------------------------
+Section 'RESULT JSON'
+$resultOk = $false
+if (-not (Test-Path $ResultFile)) {
+    Fact 'no result file - the process never got as far as writing one'
+} elseif ((Get-Item $ResultFile).Length -eq 0) {
+    # Redirection creates this file at spawn, and `claude -p` writes it only at the very
+    # end - so 0 bytes means "no result yet", and only LIVENESS above says whether that
+    # is a run still working or one that died before writing.
+    Fact '0 bytes - no result written yet. Alive above = still working; dead = died before writing'
+} else {
+    $r = Get-Content -Raw -LiteralPath $ResultFile | ConvertFrom-Json
+    $resultOk = $true
+    Fact "is_error $($r.is_error)   terminal_reason $($r.terminal_reason)   subtype $($r.subtype)   stop_reason $($r.stop_reason)"
+    Fact ("cost `$$([math]::Round($r.total_cost_usd, 4)) of `$$BudgetUsd cap{0}" -f $(if ($r.total_cost_usd -ge $BudgetUsd * 0.98) { '  <-- AT CAP' } else { '' }))
+    Fact "turns $($r.num_turns)   session_id $($r.session_id)"
+    $denials = @($r.permission_denials)
+    # NOT a failure signal on its own (#17): a real successful run on disk carries one.
+    Fact "permission_denials $($denials.Count)$(if ($denials.Count) { ': ' + (($denials.tool_name | Select-Object -Unique) -join ', ') })"
+    if ($r.api_error_status) { Fact "api_error_status $($r.api_error_status)" }
+}
+
+# --- tails ---------------------------------------------------------------------------
+if ((Test-Path $StderrFile) -and (Get-Item $StderrFile).Length -gt 0) {
+    Section "STDERR TAIL ($((Get-Item $StderrFile).Length) bytes)"
+    Get-Content -LiteralPath $StderrFile -Tail $TailLines | ForEach-Object { Fact $_ }
+}
+
+# For a wedged or killed run there is no result JSON, so the transcript is the only
+# evidence of what it was doing when it stopped - exactly the class needing most judgment.
+if (-not $resultOk -and $transcript) {
+    Section "TRANSCRIPT TAIL (last $TailLines turns - no result JSON, so this is the evidence)"
+    Get-Content -LiteralPath $transcript.FullName -Tail $TailLines | ForEach-Object {
+        try { $t = $_ | ConvertFrom-Json } catch { Fact (Clip $_); return }
+        $text = $t.message.content | ForEach-Object { if ($_.text) { $_.text } elseif ($_.name) { "[$($_.name)] $($_.input | ConvertTo-Json -Compress -Depth 3)" } }
+        Fact ("{0}: {1}" -f $t.type, (Clip ($text -join ' ')))
+    }
+}
+
+Write-Output ''
+Write-Output 'No verdict by design. Judge it: SKILL.md, "When a spawned agent fails".'

--- a/skill/scripts/status.ps1
+++ b/skill/scripts/status.ps1
@@ -48,6 +48,7 @@ function Get-Who($Row) {
 # what needs you, then what is moving, then what is next, then what is stuck
 function Get-Rank($Who, $State) {
     switch ("$Who/$State") {
+        'You/Needs you'  { -1 }
         'You/Queued'     { 0 }
         'You/Ongoing'    { 1 }
         'Caesar/Ongoing' { 2 }
@@ -83,8 +84,10 @@ foreach ($url in $MapUrl) {
     $rows = @(& $sweepScript -MapUrl $url)
     $done = @($rows | Where-Object { $_.Status -eq 'closed' } | Sort-Object ClosedAt)
     $open = @($rows | Where-Object { $_.Status -ne 'closed' } | ForEach-Object {
-        $state = switch ($_.Status) { 'blocked' { 'Blocked' } 'claimed' { 'Ongoing' } default { 'Queued' } }
-        $who = Get-Who $_
+        $state = switch ($_.Status) { 'blocked' { 'Blocked' } 'flagged' { 'Needs you' } 'claimed' { 'Ongoing' } default { 'Queued' } }
+        # A flagged ticket (#17) is back on Raj whatever its type says, and must not
+        # read as Queued - Queued means takeable. It also stops counting as an agent slot.
+        $who = if ($_.Status -eq 'flagged') { 'You' } else { Get-Who $_ }
         [pscustomobject]@{
             Number = $_.Number; Title = $_.Title; Type = $_.Type
             Who = $who; State = $state; BlockedBy = $_.BlockedBy


### PR DESCRIPTION
Builds the failure-handling policy settled in #17. Refs #26.

## 1. What changed

- **`skill/scripts/inspect-run.ps1`** (new) — a frozen script that prints the facts a failed or suspect run left behind and returns **no verdict**: liveness (PID, with a reuse check), heartbeat (mtime of the run's transcript `.jsonl`), artifact state from GitHub, the result-JSON fields, and the stderr/transcript tails. It takes the object `spawn-ticket-agent.ps1` already returns, so it pipes straight from it; a later session with only a path passes `-ResultFile` alone.
- **`skill/scripts/frontier.ps1`** — a ticket carrying `caesar:needs-raj` now reports as `flagged`, checked *ahead* of `claimed` so the flag survives an assignment being lost.
- **`skill/scripts/status.ps1`** — `flagged` renders as **Needs you**, sorts above everything else, and stops counting against the agent concurrency cap.
- **`skill/SKILL.md`** — the "Agent failure handling (#17)" stopgap under *Not yet settled* is replaced by the real rules: bad-roll vs wall, the one-retry ceiling, the per-class calls, the 30/15 look-don't-kill timer, fresh spawn over `--resume`, attempt count as a ticket comment, and flags queueing to a break in the grill.
- The **`caesar:needs-raj`** label was created on the repo.

## 2. Why

#17 proved the stopgap was actively wrong: it left a failed ticket open and **unassigned**, and `frontier.ps1` derives takeability from open + unassigned + no open blockers — so every failure went straight back on the frontier for the next session to re-fire, silently defeating the one-retry ceiling. Until this landed, Caesar had no machine-readable way to say "I stopped on this."

## 3. Proof it ran

Dogfooded on this repo, including a deliberately failed run inspected end to end.

- **0-byte dead run** — the real `ticket-21-9740` on disk (died at argv parse): reported the empty result, the missing transcript dir, and the stderr tail `error: unknown option '---'`.
- **Successful run** — the real `ticket-21-2987`: reported `is_error False`, `terminal_reason completed`, `$0.2709 of $2 cap`, and `permission_denials 1` alongside a closed ticket carrying a resolution comment — i.e. the exact combination #17's correction says is *not* a failure.
- **Live wedge, killed on purpose** — spawned a real agent at throwaway issue #27, inspected it **alive** (`pid 49300 ALIVE (claude, 421MB)`, heartbeat `6s ago`), then killed it by PID and inspected again: `pid 49300 DEAD`, heartbeat flatlined, ticket open with 0 comments, no result JSON, and a transcript tail showing it died mid-`Bash`. Worktree torn down clean by `remove-worktree.ps1`; #27 closed.
- **Flagged state** — stamped `caesar:needs-raj` on live ticket #26 and re-ran the sweep: `Status flagged`, table row `#26 / You / Needs you`, agent slots correctly dropping from 1 to 0. Label removed again afterwards.

Two bugs were caught only by running it, both silent-failure shaped:

1. `[System.IO.Path]::GetFullPath` resolves a relative path against the **process** working directory, not PowerShell's location — so the first run reported confidently on `G:\My Drive\AI_Agency\.claude\...`, a path in a different repo. Fixed by combining against `$PWD`.
2. The 0-byte result file initially read as *"the process died before writing anything"* — but redirection creates that file at spawn and `claude -p` writes it only at the very end, so a perfectly healthy live run showed as dead. Reworded to point at LIVENESS as the discriminator.

## 4. Riskiest hunks

- `skill/scripts/inspect-run.ps1:90` — the transcript-directory derivation, `$WorktreePath -replace '[:\\/.]', '-'`. It reproduces Claude Code's own dashing of a project path from observation, not from a documented contract; if that encoding changes, the heartbeat silently reports "no transcript dir" and every long run starts looking wedged.
- `skill/scripts/frontier.ps1:67` — `flagged` is checked before `claimed`. Ordering is the whole point (the flag must outlive a lost assignment), and getting it backwards would restore the exact bug this PR removes.

## 5. Blast radius, revertability

Contained. One new script that only reads — no writes to GitHub, no process control, no deletion. The two edits to existing scripts add one status value each and change no query. `SKILL.md` is prose Caesar reads. Fully revertable with `git revert`; the only out-of-tree residue is the `caesar:needs-raj` label, which is inert if unused.
