### PR TITLE
Add the veto path: veto-sweep.ps1 and SKILL.md rules (#31)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -192,6 +192,41 @@ a merge is how a spot-check degrades into a rubber stamp.
 
 Post-merge, if Raj says revert: revert on the spot, then re-ticket the redo.
 
+## When Raj vetoes a closed decision
+
+A decision already commented, closed and written into the map, that Raj now rejects.
+
+**Raj initiates.** You may flag doubt about a closed decision and stop — you never
+self-veto. Your reopen power (above) covers an answer he never accepted; it does not
+reach a ruling he made.
+
+**The map must read true.** `## Decisions so far` looks like a history log but it is the
+**session bootstrap** — every future Caesar is taught by it. A reversed line left
+standing is live misinformation. So rewrite the line **in place**: keep the ticket link,
+replace the gist with the reversal and a pointer to what supersedes it. Not struck
+through, not appended below, never deleted. Briefing, not ledger.
+
+**Unwinding is the same act as a flagged failure** — a closed resolution someone will
+not accept is one situation, differing only in who said no. So: **reopen the ticket,
+comment naming what Raj rejected and why, stamp `caesar:needs-raj`.** A veto that
+changes the *question* rather than the answer is not a veto at all; that is ordinary
+charting.
+
+**Sweep one hop, report, reopen nothing.** `scripts/veto-sweep.ps1 -Ticket <url>` lists
+every issue that cross-references the vetoed one. It returns no verdict: separate
+load-bearing dependants from passing citation yourself, propose an action per dependant,
+and wait for his word. A second hop only where hop one came back contaminated.
+
+Do not reach for `gh search issues` — #30 measured it at 12 hits of ~20 against the
+timeline's 5, and the noise reads exactly like a real report. Known gap, accepted: the
+sweep sees only tickets that wrote the link.
+
+**In-flight agents are just another class of dependant.** The sweep reports them with
+their PID; drain or kill is Raj's call. No second mechanism.
+
+If the vetoed decision has already shipped, the code half is the merge gate's revert
+(above). This path owns the map-and-ticket half.
+
 ## Worktrees
 
 Every spawned agent gets its own, always — `--worktree` inside the spawn script. Not
@@ -249,8 +284,6 @@ Deliberately absent, and tracked as open tickets on Caesar's own map:
   picture, including a ticket assigned to Raj with no live process behind it.
 - **Charting new maps** — whether you may run `/wayfinder` in charting mode, or only
   work existing maps. Assume only existing maps until decided.
-- **Veto after the fact** — Raj disagreeing with a decision already commented, closed
-  and written into the map.
 
 Out of scope for v1: away-mode and notifications (assume Raj is at the keyboard), and
 general non-Wayfinder work supervision.

--- a/skill/scripts/veto-sweep.ps1
+++ b/skill/scripts/veto-sweep.ps1
@@ -1,0 +1,101 @@
+<#
+.SYNOPSIS
+  Frozen veto sweep. Lists every issue that cross-references a decision Raj has vetoed,
+  and returns NO verdict (issue #30).
+
+.DESCRIPTION
+  Frozen for the same reason as inspect-run: the fragile part is reaching for the right
+  command, not making the call. During #30's grilling the wrong command was reached for
+  first and looked entirely convincing - `gh search issues` returned 12 hits of ~20
+  where the timeline returns 5, and the noise reads exactly like a real report. A
+  one-line veto acted on that would have blown up half the map.
+
+  So: the issue timeline, filtered to `cross-referenced`. One hop only. Which hits are
+  load-bearing dependants and which are passing citation is judgment - the API cannot
+  tell them apart, and neither can this script.
+
+  Known gap, accepted in #30: the sweep sees only tickets that actually wrote the link.
+
+.EXAMPLE
+  .\veto-sweep.ps1 -Ticket https://github.com/Dhillvn/caesar/issues/7
+  .\veto-sweep.ps1 -Ticket 7 -Repo Dhillvn/caesar
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$Ticket,
+    [string]$Repo,
+    [string]$RepoPath = $PWD.Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($Ticket -match '^https?://github\.com/([^/]+/[^/]+)/issues/(\d+)') {
+    if (-not $Repo) { $Repo = $Matches[1] }
+    $number = [int]$Matches[2]
+} elseif ($Ticket -match '^#?(\d+)$') {
+    $number = [int]$Matches[1]
+    if (-not $Repo) { $Repo = (gh repo view --json nameWithOwner --jq '.nameWithOwner') }
+} else {
+    throw "Not an issue URL or number: $Ticket"
+}
+if (-not $Repo) { throw 'Could not determine owner/repo - pass -Repo.' }
+
+# --- the vetoed decision itself ------------------------------------------------------
+$subject = gh issue view $number --repo $Repo --json number,title,state,labels | ConvertFrom-Json
+Write-Output ("VETO SWEEP  {0}#{1}  {2}" -f $Repo, $subject.number, $subject.title)
+Write-Output ("  state {0}   labels {1}" -f $subject.state, (($subject.labels.name -join ', ')))
+
+# --- one hop of cross-references -----------------------------------------------------
+# NOT `gh search issues` (#30). --slurp merges the paginated arrays into one array of
+# arrays, hence the flattening pass. No --jq anywhere: a space-bearing filter expression
+# is shredded when it travels through argv to a native tool (#24).
+$pages = gh api "repos/$Repo/issues/$number/timeline?per_page=100" --paginate --slurp | ConvertFrom-Json
+if ($LASTEXITCODE -ne 0) { throw "gh api timeline failed for $Repo#$number" }
+
+$hits = $pages |
+    ForEach-Object { $_ } |
+    Where-Object { $_.event -eq 'cross-referenced' -and $_.source.issue } |
+    ForEach-Object {
+        $i = $_.source.issue
+        [pscustomobject]@{
+            Number = $i.number
+            State  = $i.state
+            Kind   = if ($i.pull_request) { 'pr' }
+                     elseif ($i.labels.name -contains 'wayfinder:map') { 'map' }
+                     else { (($i.labels.name | Where-Object { $_ -like 'wayfinder:*' }) -replace 'wayfinder:', '') -join ',' }
+            Title  = $i.title
+            InFlight = ''
+        }
+    } |
+    Sort-Object Number -Unique
+
+# --- which of them have an agent running right now ------------------------------------
+# No state file (#11): a spawned agent's own command line carries `--worktree
+# ticket-<n>-<rand>`, so the process table is the truth about what is in flight.
+$live = @{}
+foreach ($p in Get-CimInstance Win32_Process -ErrorAction SilentlyContinue) {
+    if ($p.CommandLine -match 'ticket-(\d+)-\d+') {
+        $n = [int]$Matches[1]
+        if (-not $live[$n]) { $live[$n] = @() }
+        $live[$n] += $p.ProcessId
+    }
+}
+foreach ($h in $hits) { if ($live[$h.Number]) { $h.InFlight = "pid $($live[$h.Number] -join ',')" } }
+
+Write-Output ''
+if (-not $hits) {
+    Write-Output 'No cross-references. Nothing cites this decision.'
+} else {
+    Write-Output ("{0} cross-reference(s), one hop:" -f @($hits).Count)
+    $hits | Format-Table Number, State, Kind, InFlight, Title -AutoSize | Out-String -Width 200 | Write-Output
+}
+
+# An in-flight dependant is the one hit that cannot simply be re-read later: it is
+# writing right now, on a premise that has just been withdrawn.
+if ($live.Count) {
+    Write-Output ("IN FLIGHT: ticket(s) {0} have a live agent. Drain or kill is Raj's call (#30)." -f (($live.Keys | Sort-Object) -join ', '))
+    Write-Output ''
+}
+
+Write-Output 'No verdict by design. Judge it: SKILL.md, "When Raj vetoes a closed decision".'
+Write-Output 'The map issue is always a hit - it links every ticket. That is the map line, not a dependant.'


### PR DESCRIPTION
Builds the ruling in #30. Ticket: #31.

## 1. What changed

- **`skill/scripts/veto-sweep.ps1`** (new, frozen). Takes a ticket URL or number, prints every issue that cross-references it — number, state, kind (`map` / `pr` / the wayfinder type), title — and flags any dependant with a live spawned agent by PID. Returns **no verdict**, matching the shape `inspect-run.ps1` established.
- **`skill/SKILL.md`** — new section *"When Raj vetoes a closed decision"*: map line rewritten in place (briefing, not ledger), reopen + veto comment + `caesar:needs-raj`, sweep one hop and report, Raj initiates and Caesar never self-vetoes, shipped code falls to the existing revert path. The `Veto after the fact` bullet is removed from *Not yet settled*.

No new label — `caesar:needs-raj` already exists and is already read by `frontier.ps1` and `status.ps1`.

## 2. Why

#30 ruled that a vetoed decision must be rewritten in place because `## Decisions so far` is the session bootstrap, not a history log, and that the dependant sweep must use the issue timeline rather than `gh search issues` — measured at 12 hits of ~20 against the timeline's 5, with the noise reading exactly like a real report.

## 3. Proof it ran

Dogfooded on this live map, three runs:

- `-Ticket https://github.com/Dhillvn/caesar/issues/16` → 14 cross-references, correctly kinded (`#1` as `map`, `#25` as `pr`, the rest by wayfinder type).
- `-Ticket 7 -Repo Dhillvn/caesar` (number form, repo inferred path exercised separately) → 12 cross-references.
- In-flight detection proven against a stand-in process whose command line carries `--worktree ticket-30-4242`: the `#30` row rendered `pid 32500` and the summary line fired. Both the per-row column and the summary are covered.

Read-only against GitHub — no issue writes, so there was nothing to run on a throwaway.

## 4. Riskiest hunks

- `skill/scripts/veto-sweep.ps1:60` — the `--slurp` result is an array *of arrays*, so the flattening `ForEach-Object { $_ }` is load-bearing; without it the pipeline silently yields nothing on a multi-page timeline. Single-page repos would not expose this.
- `skill/scripts/veto-sweep.ps1:83` — in-flight detection enumerates the whole process table and matches `ticket-(\d+)-\d+` against each command line. Any unrelated process carrying that string would be reported as an agent.

Deliberately avoided: no `--jq` anywhere, since a space-bearing filter expression is shredded travelling through argv to a native tool.

## 5. Blast radius

Additive. One new read-only script and one new SKILL.md section; nothing existing changes behaviour, and no script that writes to GitHub is touched. Fully revertable with a single revert commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
