### PR TITLE
Make the map-body write safe (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,29 @@ workflow. Concept ports; implementation (tmux, multi-harness hooks, secondmates,
 macOS notifications) does not. Caesar needs its spawn and escalate layers, not its state layer —
 the Wayfinder map already **is** the queue.
 
+## The PowerShell rule
+
+Every silent-failure bug this repo has shipped is one family: **content with spaces or
+newlines shredded by passing it through PowerShell** — a deny list split on its internal
+space (#19), a `--jq` expression split the same way (#24), a `git commit -m` here-string
+dying at the first newline (#32), and a whole 25 KB map body flattened to one line by
+`--jq .body | Set-Content -NoNewline`, because native output is an **array of lines** and
+`-NoNewline` joins an array with no separator (#36). Every one of them looked correct
+while reading and failed without an error.
+
+So, when content travels:
+
+- **To a native tool: through a file** — `--body-file`, `--input`, `-F`. Never argv.
+- **From a native tool: to a file** — `Start-Process -RedirectStandardOutput`. Never a
+  variable, if the value is going to be written back somewhere.
+- **Splitting or joining lines yourself: say the separator out loud** — an explicit
+  newline in `-split` / `-join`, or `[IO.File]::ReadAllText`/`WriteAllText`. `-NoNewline` on anything that
+  might be an array is banned outright.
+- **Any `^`-anchored regex: apply it to a string, never to an array.** `^` never matches
+  in an array pipeline, so the check silently reports zero and reads as a clean result.
+- **Verify structure, not phrasing.** A check that asks "is the old text gone?" passes on
+  a destroyed file.
+
 ## Agent skills
 
 ### Issue tracker

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -365,6 +365,32 @@ hard 400, not a 412, so there is no optimistic concurrency to lean on. Every map
 write is **read-verify-retry**: re-read, write, re-read to confirm, retry on mismatch.
 Parallel grill-only sessions make this load-bearing, not theoretical.
 
+**Never compose that by hand. `scripts/map-body.ps1` is the only way you touch the map
+body**, in two steps:
+
+```
+.\map-body.ps1 -MapUrl <url>                      # fetch -> a file, and that file is the backup
+.\map-body.ps1 -MapUrl <url> -BodyFile <path>     # edit the file, then write it back
+```
+
+Edit the **file** on disk between the two calls. The body must never become a PowerShell
+value: a native command's output is captured as an *array of lines*, and one wrong join
+flattens the whole map to a single line that GitHub accepts without complaint. That is
+how 25 KB of decisions were destroyed in #36, and **GitHub keeps no revision history for
+an API body edit** — the pre-write copy under `.claude/caesar-runs/map-backups/` is the
+only undo that exists.
+
+The script verifies **structure, not phrasing**: line, heading and decision-bullet
+counts, every previously-present ticket link, and a byte floor — checked before the
+write, so a bad edit is refused on disk rather than repaired on GitHub. A phrase check
+("is the stale line gone?") passes on a destroyed map; that is exactly what it did.
+
+Read the verdict it returns. `Written=$false` with `refused before writing` means nothing
+happened and your file is wrong — fix the file. `WRITTEN BUT DAMAGED` means GitHub stored
+something other than what you sent: run the `Restore` command it prints, immediately.
+`-AllowShrink` exists for a section you meant to delete; needing it is a claim you are
+making, so say so in chat.
+
 ## Register
 
 Raj's internal register is caveman mode — terse, no filler. Code, commits and PRs stay

--- a/skill/scripts/map-body.ps1
+++ b/skill/scripts/map-body.ps1
@@ -1,0 +1,191 @@
+<#
+.SYNOPSIS
+  Frozen map-body read/write. Body content never passes through a PowerShell string:
+  GitHub -> file on fetch, file -> GitHub on write. Every write is backed up first and
+  refused if it would shrink the map's structure.
+
+.DESCRIPTION
+  Frozen because the unsafe version looks identical to the safe one and destroys the
+  map without an error (issue #36). A body round-tripped through
+  `gh issue view --jq .body | Set-Content -NoNewline` is captured by PowerShell as an
+  ARRAY OF LINES, and -NoNewline joins an array with no separator at all - so all
+  25 KB came back as a single line with every heading and bullet gone, and GitHub
+  accepted it silently. GitHub keeps no revision history for an API body edit, so
+  without a pre-write copy the map is unrecoverable.
+
+  Two rules follow, and both live here rather than in a session's judgment:
+
+  1. The body is moved as bytes, never as a variable. Fetch redirects gh's stdout
+     straight to a file; write uses `--body-file`. Nothing in between splits lines.
+  2. "Verify" is structural, not a phrase check. The write that destroyed the map
+     passed its verify, because the check asked "is the stale phrase gone?" - which
+     was true. Heading count, decision-bullet count, ticket links and a byte floor
+     are what actually separate a good write from a catastrophic one.
+
+  The shape check runs BEFORE the write as well as after it, so the common case is
+  refused on disk rather than repaired on GitHub.
+
+.EXAMPLE
+  # fetch the live body to a file, then edit that file
+  .\map-body.ps1 -MapUrl https://github.com/Dhillvn/caesar/issues/1
+
+.EXAMPLE
+  # write the edited file back, with backup + pre/post shape check
+  .\map-body.ps1 -MapUrl https://github.com/Dhillvn/caesar/issues/1 -BodyFile .\map.md
+
+.EXAMPLE
+  .\map-body.ps1 -SelfCheck
+#>
+[CmdletBinding()]
+param(
+    [string]$MapUrl,
+    [string]$BodyFile,
+    # A legitimate shrink (a section genuinely deleted) needs saying out loud.
+    [switch]$AllowShrink,
+    [switch]$SelfCheck
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- shape: the invariants that tell a good write from a catastrophic one ----------
+
+function Get-BodyShape([string]$text) {
+    # Normalise first, and measure only the normalised text. `gh --jq` appends a newline
+    # to its output, so a fetched body is always one byte and one line longer than the
+    # file that produced it - post-verify reported that as damage until this trimmed.
+    $text = ($text -replace "`r", '').TrimEnd("`n")
+    # Split explicitly. Applying a ^-anchored regex to an array is the sibling bug that
+    # made the first damage-check report 0 headings on a healthy map (#36).
+    $lines = $text -split "`n"
+    [pscustomobject]@{
+        Bytes    = [Text.Encoding]::UTF8.GetByteCount($text)
+        Lines    = $lines.Count
+        Headings = @($lines | Where-Object { $_ -match '^#{1,3} ' }).Count
+        Bullets  = @($lines | Where-Object { $_ -match '^- \[' }).Count
+        Links    = @([regex]::Matches($text, 'https://github\.com/[^/\s)]+/[^/\s)]+/issues/\d+') |
+                    ForEach-Object { $_.Value } | Sort-Object -Unique)
+    }
+}
+
+function Test-BodyShape($old, $new) {
+    $problems = @()
+    foreach ($f in 'Lines', 'Headings', 'Bullets') {
+        if ($new.$f -lt $old.$f) { $problems += "$f dropped $($old.$f) -> $($new.$f)" }
+    }
+    # 10% is slack for a rewritten gist, not for a lost section - the failure this
+    # guards took 25 KB to one line, and a real edit that sheds a tenth of the map is
+    # something Caesar should have to state.
+    if ($new.Bytes -lt [int]($old.Bytes * 0.9)) {
+        $problems += "bytes dropped $($old.Bytes) -> $($new.Bytes) (>10%)"
+    }
+    $lost = @($old.Links | Where-Object { $new.Links -notcontains $_ })
+    if ($lost.Count) { $problems += "$($lost.Count) ticket link(s) vanished: $($lost -join ', ')" }
+    , $problems
+}
+
+if ($SelfCheck) {
+    $good = "## A`n`n- [t](https://github.com/o/r/issues/2) - gist`n`n## B`n"
+    $collapsed = ($good -replace "`n", '')          # the exact #36 failure
+    $grown = $good + "- [u](https://github.com/o/r/issues/3) - gist`n"
+    $a = Get-BodyShape $good
+    if ($a.Headings -ne 2) { throw "SelfCheck: headings $($a.Headings), expected 2" }
+    if ($a.Bullets -ne 1) { throw "SelfCheck: bullets $($a.Bullets), expected 1" }
+    if ($a.Links.Count -ne 1) { throw "SelfCheck: links $($a.Links.Count), expected 1" }
+    if (-not (Test-BodyShape $a (Get-BodyShape $collapsed)).Count) { throw 'SelfCheck: collapse not caught' }
+    if ((Test-BodyShape $a (Get-BodyShape $grown)).Count) { throw 'SelfCheck: normal growth refused' }
+    if (-not (Test-BodyShape $a (Get-BodyShape ($good -replace 'issues/2', 'issues/9'))).Count) {
+        throw 'SelfCheck: lost ticket link not caught'
+    }
+    Write-Output 'SelfCheck OK'
+    return
+}
+
+# --- plumbing ---------------------------------------------------------------------
+
+if (-not $MapUrl) { throw 'MapUrl is required (or use -SelfCheck)' }
+if ($MapUrl -notmatch '^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)') {
+    throw "Not a GitHub issue URL: $MapUrl"
+}
+$owner = $Matches[1]; $repo = $Matches[2]; $num = [int]$Matches[3]
+$slug = "$owner/$repo"
+
+$gh = (Get-Command gh -ErrorAction Stop).Source
+# -C against PowerShell's location, never bare git: a native command inherits the
+# PROCESS cwd, which Set-Location does not move, and that gap already made one script
+# report confidently on another repo (#26).
+$here = (Get-Location).Path
+$root = (& git -C $here rev-parse --show-toplevel 2>$null)
+if ($LASTEXITCODE -ne 0 -or -not $root) { $root = $here }
+$backupDir = Join-Path ([string]$root).Trim() '.claude/caesar-runs/map-backups'
+if (-not (Test-Path $backupDir)) { New-Item -ItemType Directory -Path $backupDir -Force | Out-Null }
+
+function Get-LiveBody([string]$destination) {
+    # Bytes straight to disk. gh's stdout never becomes a PowerShell value, so there is
+    # no array to be joined wrongly and no encoding pass. None of these arguments can
+    # contain a space, which is what makes ArgumentList safe here (#24).
+    $p = Start-Process -FilePath $gh -NoNewWindow -Wait -PassThru `
+        -ArgumentList @('api', "repos/$slug/issues/$num", '--jq', '.body') `
+        -RedirectStandardOutput $destination
+    if ($p.ExitCode -ne 0) { throw "gh api failed reading $slug#$num (exit $($p.ExitCode))" }
+    if (-not (Test-Path $destination)) { throw "no body written to $destination" }
+    [IO.File]::ReadAllText($destination)
+}
+
+$stamp = (Get-Date).ToUniversalTime().ToString('yyyyMMdd-HHmmss')
+$backup = Join-Path $backupDir "$owner-$repo-$num-$stamp.md"
+
+# --- fetch mode -------------------------------------------------------------------
+
+if (-not $BodyFile) {
+    $text = Get-LiveBody $backup
+    return [pscustomobject]@{
+        Repo  = $slug
+        Issue = $num
+        Path  = $backup
+        Shape = Get-BodyShape $text
+    }
+}
+
+# --- write mode -------------------------------------------------------------------
+
+if (-not [IO.Path]::IsPathRooted($BodyFile)) { $BodyFile = Join-Path $here $BodyFile }
+$BodyFile = [IO.Path]::GetFullPath($BodyFile)
+if (-not (Test-Path $BodyFile)) { throw "BodyFile not found: $BodyFile" }
+
+$oldText = Get-LiveBody $backup            # the backup IS the pre-write read
+$oldShape = Get-BodyShape $oldText
+$newShape = Get-BodyShape ([IO.File]::ReadAllText($BodyFile))
+
+function New-Verdict($written, $reason, $problems) {
+    [pscustomobject]@{
+        Repo     = $slug
+        Issue    = $num
+        Written  = $written
+        Reason   = $reason
+        Backup   = $backup
+        Old      = $oldShape
+        New      = $newShape
+        Problems = @($problems)
+        Restore  = "gh issue edit $num --repo $slug --body-file `"$backup`""
+    }
+}
+
+$problems = Test-BodyShape $oldShape $newShape
+if ($problems.Count -and -not $AllowShrink) {
+    return New-Verdict $false 'refused before writing - shape shrank' $problems
+}
+
+& $gh issue edit $num --repo $slug --body-file $BodyFile | Out-Null
+if ($LASTEXITCODE -ne 0) { return New-Verdict $false 'gh issue edit failed' @() }
+
+# Post-verify against what GitHub actually stored, not against what we sent.
+$liveText = Get-LiveBody ([IO.Path]::GetTempFileName())
+$liveShape = Get-BodyShape $liveText
+$drift = @(foreach ($f in 'Lines', 'Headings', 'Bullets', 'Bytes') {
+        if ($liveShape.$f -ne $newShape.$f) { "$f sent $($newShape.$f), stored $($liveShape.$f)" }
+    })
+if ($drift.Count) {
+    return New-Verdict $false 'WRITTEN BUT DAMAGED - restore from backup' $drift
+}
+
+New-Verdict $true 'written and verified' $problems


### PR DESCRIPTION
## What changed

`skill/scripts/map-body.ps1` — a frozen fetch/write for the map body, plus the SKILL.md rules that route Caesar through it and a repo-level rule in CLAUDE.md.

- **Fetch**: `gh` stdout is redirected straight to a file (`Start-Process -RedirectStandardOutput`). The body never becomes a PowerShell value.
- **Write**: `--body-file`, from the file you edited. Same rule in reverse.
- **Backup**: every write first snapshots the live body to `.claude/caesar-runs/map-backups/<owner>-<repo>-<n>-<utc>.md` and prints the one-line `Restore` command.
- **Verify**: structural, and run **before** the write as well as after. Line, heading and decision-bullet counts, every previously-present ticket link, and a 10% byte floor. A shrink is refused on disk; `-AllowShrink` is the explicit escape. After the write it re-reads what GitHub actually stored and compares shapes.
- **`-SelfCheck`**: offline assertions over the shape/compare logic, including the exact #36 collapse.

## Why

Issue #36. A hand-driven map edit round-tripped the body through `gh issue view --jq .body | Set-Content -NoNewline`. PowerShell captures native output as an **array of lines**, and `-NoNewline` joins an array with *no separator*, so the 25 KB map was written back as one line — every heading, every decision bullet, both trailing sections gone. GitHub accepted it without complaint, the verify passed because it only asked "is the stale phrase gone?", and **GitHub keeps no revision history for an API body edit**. Recovery depended entirely on a copy that happened to be on disk.

## Proof it ran

`-SelfCheck` passes, and the script was dogfooded end to end against **throwaway issue #37**, deliberately not a live map because a bad write here mangles issues:

| Case | Result |
|---|---|
| Fetch | 18 lines / 4 headings / 2 bullets / 2 links, correct |
| **The #36 bug reproduced** (all newlines stripped) | refused before writing — `Lines 18 -> 1`, `Headings 4 -> 1`, `Bullets 2 -> 0` |
| A decision bullet silently deleted | refused before writing — `Bullets 2 -> 1`, bytes >10% down, `1 ticket link vanished: .../issues/102` |
| Legitimate append | written and verified, `L17 H4 B3 429b -> L18 H4 B4 510b` |
| Deliberate deletion with `-AllowShrink` | written and verified |

Two bugs were caught only by running it, both invisible to reading: an absolute `-BodyFile` was `Join-Path`ed onto the cwd and threw inside `GetFullPath`; and `gh --jq` appends a trailing newline to its output, so every fetched body is one byte and one line longer than the file that produced it — post-verify called a perfectly good write `WRITTEN BUT DAMAGED` until the shape function normalised trailing newlines and CRs.

## Riskiest hunks

1. `skill/scripts/map-body.ps1:183` — the post-write drift check. It is the last line of defence, and it fires *after* GitHub has already been changed, so its only remedy is the printed `Restore` command. A false negative here is a silently damaged map.
2. `skill/scripts/map-body.ps1:78` — the 10% byte floor. Too tight and every ordinary edit needs `-AllowShrink`, which trains Caesar to pass it reflexively and disarms the whole check.

## Blast radius

Additive. New script plus documentation; nothing existing calls it yet, so unmerged behaviour is unchanged and the only way to regress is to keep hand-writing the body, which is what this removes. Fully revertable — one revert restores the previous state, and the map itself is untouched by the revert either way.
