### PR TITLE
Build charting into SKILL.md (#39)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -31,6 +31,9 @@ the URL. Two roles:
 
 Only one primary at a time.
 
+`/caesar` with a **loose idea and no URL** charts a new map first, then drives it — see
+*Charting a new map* below.
+
 ## Starting a session
 
 `/caesar <map-url>` is the only door. There is no `resume` variant: there is no state
@@ -125,6 +128,78 @@ drop. Every dangerous command here is already frozen; the three additions are fl
 one-liners, and the reconciliation is judgment by definition. A `startup.ps1` would close
 no silent-failure mode. It earns one only if dogfooding shows the startup being skipped or
 costing visible context.
+
+## Charting a new map
+
+Raj arrives with a loose idea and no map. You chart it and then you drive it — charting
+is not a separate session that hands over.
+
+**The repo constraint, checked first.** A map is issues in a git repo: every frozen script
+talks to `gh` against that repo, and `--worktree` is repo-local. So you must be inside a
+git repo with issues enabled. If the idea has no repo, say so plainly and offer to stand
+one up (`gh repo create`, private) as the map's first AFK `task` ticket. Never dead-end on
+it, and never try to host a map in Drive markdown.
+
+Then, in order:
+
+1. **Name the destination.** Grill (`/grilling`, `/domain-modeling`) until it is one or two
+   lines: the spec, decision or change this effort is finding its way to. Scope before
+   route — the destination is what fixes in and out.
+2. **Grill again, breadth-first.** Fan out across the whole space rather than deep on one
+   thread: the open decisions, and the first steps takeable now. **If no fog surfaces** —
+   the way is already clear and the whole thing fits one session — there is nothing to
+   chart. Say so and ask him how he wants to proceed.
+3. **Create the map**, labelled `wayfinder:map`, body in Wayfinder's shape: Destination and
+   Notes filled in, Decisions-so-far empty, the fog in **Not yet specified**.
+4. **Create the tickets** you can specify now, each labelled `wayfinder:<type>`, and attach
+   each to the map as a sub-issue.
+5. **Wire blocking in a second pass** — issues need ids before they can reference each
+   other, so this cannot be folded into step 4.
+
+```
+gh issue create --label wayfinder:map --title "..." --body-file <file>
+gh issue create --label wayfinder:<type> --title "..." --body-file <file>
+gh api repos/<owner>/<repo>/issues/<n> --jq .id
+gh api --method POST repos/<owner>/<repo>/issues/<map>/sub_issues -F sub_issue_id=<child-db-id>
+gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>
+```
+
+Both relationship endpoints take the numeric **database id**, not the `#number` and not the
+`node_id`. Bodies travel **through a file** — a multi-line body dies at the first newline in
+argv.
+
+**The labels must already exist in the target repo.** `gh issue create --label` hard-errors
+on an unknown label and creates nothing — so in a repo that has never held a map, run
+`gh label create wayfinder:map` and one per `wayfinder:<type>` you are about to use, first.
+
+No new script for any of this: these are flagless one-liners and the rest is judgment, the
+same reasoning that kept startup as prose.
+
+**Fog, not pre-sliced tickets.** The test is whether you can *state* the question sharply
+now — not whether you can answer it. Sharp but blocked → a ticket. Not yet sharp → one loose
+line under **Not yet specified**. Do not slice fog into ticket-shaped pieces; one patch may
+graduate into several tickets, or none.
+
+**Declare the shape before you drive.** Name in a line or two what this map will actually
+exercise — two agents running concurrently, a PR merge gate — and what it will not touch. A
+map that empties without exercising them is a **partial**, and that is declared up front,
+not argued afterwards.
+
+**Then drive.** Do not stop at the handover: name the first ticket you are taking and why,
+and go straight into the loop.
+
+### Why this is not `/wayfinder` in charting mode
+
+Two of its charting instructions contradict locked decisions here, and "follow it except
+those two bits" is exactly the improvisation surface the frozen scripts exist to kill:
+
+- *"Fire the research subagents"* — research tickets go out as headless agents through
+  `spawn-ticket-agent.ps1`, never subagents.
+- *"Stop — charting is one session's work; it hand-resolves nothing"* — charting flows into
+  driving.
+
+Everything else in its charting mode carries over on its merits, and is written out above
+rather than referenced.
 
 ## The loop
 
@@ -397,12 +472,7 @@ Raj's internal register is caveman mode — terse, no filler. Code, commits and 
 normal prose. He is a solo operator still learning GitHub, so never make him drive the
 tracker himself: report state in chat, and act on his sentence.
 
-## Not yet settled
+## Out of scope for v1
 
-Deliberately absent, and tracked as open tickets on Caesar's own map:
-
-- **Charting new maps** — whether you may run `/wayfinder` in charting mode, or only
-  work existing maps. Assume only existing maps until decided.
-
-Out of scope for v1: away-mode and notifications (assume Raj is at the keyboard), and
-general non-Wayfinder work supervision.
+Away-mode and notifications (assume Raj is at the keyboard), and general non-Wayfinder
+work supervision.


### PR DESCRIPTION
## 1. What changed

`skill/SKILL.md` gains a **`## Charting a new map`** section, sited between session startup
and the loop, plus a one-line pointer in `## Invocation and roles`. The `## Not yet settled`
section is removed — its only bullet was charting — and its trailing out-of-scope sentence is
promoted to `## Out of scope for v1`.

The section carries: the repo constraint checked first, the five-step sequence (name the
destination → breadth-first grill → create the map → create the tickets → wire blocking in a
second pass), the exact `gh` command block, the fog-vs-ticket test, declaring the shape, and
flowing into the loop rather than stopping. A short subsection records *why* this is Caesar's
own prose and not `/wayfinder` in charting mode, so a future Caesar does not helpfully
"restore" the two instructions that contradict locked decisions.

## 2. Why

Closes #39, which builds the charting half of #35. #35 rejected the invoke-`/wayfinder`-with-
overrides route: *"fire the research subagents"* contradicts #7's headless spawn, and *"stop —
charting hand-resolves nothing"* contradicts charting flowing into driving. #11's freeze
rationale says "follow it except these two bits" is exactly the improvisation surface to kill.

No new script, per #39 and #29's reasoning — every command here is a flagless one-liner and
the rest is judgment.

## 3. Proof it ran

Prose cannot be verified by reading, which is the failure mode this repo has hit five times,
so the command block was **dogfooded verbatim on a throwaway map** in this repo (issues
#41/#42/#43, all now closed):

- `gh issue create --label wayfinder:map --body-file` — multi-line body with an em dash and a
  backtick survived the round trip intact (17 lines out, plus `--jq`'s known trailing newline).
- Both tickets created and attached via the `sub_issues` endpoint with the numeric database
  id; both accepted.
- One `dependencies/blocked_by` edge added between them; accepted.
- **The frozen sweep then read the charted map correctly**: `frontier.ps1` returned #42
  `frontier` / #43 `blocked` by 42, and `status.ps1` rendered #42 as Caesar's `task` **Queued**
  and #43 as Raj's `grilling` **Blocked #42**. That is the end-to-end claim — a map charted by
  these commands is drivable by the existing machinery.

**One gap was found only by running it**, and is now in the section: `gh issue create --label`
**hard-errors on a label that does not exist** and creates nothing. Probed directly
(`could not add label: 'wayfinder:zzz-does-not-exist' not found`, no issue created). Charting
into a repo that has never held a map would have failed on its first command without this.

## 4. Riskiest hunks

- `skill/SKILL.md:163` — the `sub_issues` / `dependencies` command block. It is the only place
  in the section where a wrong id kind fails quietly rather than loudly; both lines are stated
  as taking the **database id**, and both were run as written above.
- `skill/SKILL.md:188` — *"Then drive."* This is the instruction that makes a charting session
  keep going instead of stopping, so it is the line that spends tokens if it is wrong. It is
  #35's ruling verbatim, not an inference.

## 5. Blast radius, revertability

Documentation only — one file, no script touched, no behaviour change to any frozen command.
It reaches Caesar the moment it is on `main`, since the skill is junctioned and loads live.
Fully revertable: `git revert` on one commit, nothing on disk or on GitHub depends on it.

Unblocks #40, the proving run.
