### PR TITLE
Wake Caesar on centurion landings

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -49,7 +49,9 @@ same truth; only what the sweep *finds* differs.
    corpus behind *you are the smell test*, and it carries the per-map config overrides.
 2. **`scripts/frontier.ps1 -MapUrl <url>`**
 3. **`git worktree list`** — unconditionally, not only when a claimed row appears. The
-   orphan case below is visible only from the disk side.
+   orphan case below is visible only from the disk side. **If it shows a live `ticket-N-*`,
+   arm the watcher before anything else** (see *The watcher*): that centurion was
+   dispatched by a session that is gone, so you are now its only route back to Raj.
 4. **`gh pr list`** — an open PR awaiting the merge word is the one piece of prior state
    nothing else surfaces. Skip it and a decision of Raj's is silently dropped forever.
 
@@ -212,8 +214,9 @@ rather than referenced.
 3. **Grill.** Take one HITL ticket (`grilling`, `prototype`, HITL `task`) and work it
    with Raj in-session. There is no relay and no handoff: subagents cannot converse
    with a human, so you *are* the channel.
-4. **Harvest.** As centurions land, verify each against GitHub, append its gist to the map,
-   tear down its worktree.
+4. **Harvest.** A landing **wakes you** — the watcher below emits one line per event, and
+   that line arrives even while you sit idle mid-grill. On each: verify against GitHub,
+   append the gist to the map, tear down the worktree.
 5. **Repeat** until the frontier is empty.
 
 Never resolve more than one HITL ticket per session. Research tickets are exempt.
@@ -244,6 +247,42 @@ artifact: is the issue closed, does it carry a resolution comment.
 8 cores, 15.7 GB with ~2.3 GB free, each at 150–400 MB. It also bounds spend and
 blast radius. Per-ticket spend is capped by `-BudgetUsd` (default 2.0). Both are
 overridable per-map in the map's own **Notes** section.
+
+### The watcher — how a landing reaches you
+
+`spawn-ticket-agent.ps1` detaches and returns immediately, so a finished centurion reaches
+nothing on its own: no `SubagentStop`, no background-task completion, no entry in `claude
+agents`. Without a watcher your only wake is Raj typing, and nothing obliges you to check
+on that turn — which is how a landed scout sits unreported until he asks. **He should never
+have to ask.**
+
+**Arm it once per session, at your first dispatch**, and leave it up:
+
+```
+Monitor(command: 'powershell -NoProfile -ExecutionPolicy Bypass -File
+        <skill>\scripts\watch-runs.ps1 -RepoPath <repo>',
+        description: 'centurion landings', persistent: true)
+```
+
+One watcher covers every centurion on the machine, however many maps dispatched them — do
+not arm one per ticket. It backfills silently on start, so re-arming after a crash replays
+nothing and cannot double-append a gist to the map.
+
+Five events, and **it returns no verdict** — same as `inspect-run.ps1`:
+
+| Event | What it means |
+|---|---|
+| `LANDED` | result JSON parsed, `GIST:` line carried on the event — verify, then append |
+| `LANDED-NO-GIST` | exit clean, no `GIST:` printed — verify the ticket before appending anything |
+| `ERRORED` | `is_error: true`, with `terminal_reason` and cost |
+| `QUIET` | transcript has not advanced past the timer — **look, do not kill** |
+| `NO-TRANSCRIPT` | past the timer and the session never wrote a turn — it may never have started |
+
+`LANDED` is not "accept the gist" and `QUIET` is not "kill it". The failure table below
+makes both calls, unchanged.
+
+**Never hand-poll the run directory.** The watcher is the only mechanism; a hand-poll only
+fires on a turn you already have, which is the failure this replaces.
 
 ### Reporting mid-grill
 
@@ -287,11 +326,16 @@ disk carries one. Denials count only when no artifact landed.
 
 ### The timer: look, do not kill
 
-**At 30 minutes you look; you do not kill.** Read the heartbeat: still moving → the
-ticket is genuinely long, let it run and re-check in 15. Not moving → wedged, kill by
-PID and triage on the tails. A hard kill at the clock bins legitimately slow work, and
-`--max-budget-usd` already bounds a runaway. Both intervals are overridable per-map in
-the map's **Notes**.
+**At 30 minutes you look; you do not kill.** The clock is the watcher's — a centurion whose
+transcript has not advanced arrives as a `QUIET` event, and re-arrives every 15 minutes
+while it stays quiet, so a wedge cannot go silent again after one notice. You are never the
+one counting; before the watcher existed this rule had no clock at all and so never fired.
+
+On a `QUIET`, read the heartbeat: still moving → the ticket is genuinely long, let it run.
+Not moving → wedged, kill by PID and triage on the tails. A hard kill at the clock bins
+legitimately slow work, and `--max-budget-usd` already bounds a runaway. Both intervals are
+`-QuietMinutes` / `-RecheckMinutes` on the watcher, overridable per-map in the map's
+**Notes**.
 
 A wedge is not automatically a flag — a dropped connection is a bad roll, a loop is a
 wall, and the table above already tells them apart.
@@ -546,5 +590,10 @@ report state in chat, and act on his sentence.
 
 ## Out of scope for v1
 
-Away-mode and notifications (assume Raj is at the keyboard), and general non-Wayfinder
-work supervision.
+General non-Wayfinder work supervision.
+
+Landing notifications were listed here — *"assume Raj is at the keyboard"* — until the
+assumption was tested and found wrong twice over: he is often away, and being present
+never woke you either, because nothing reached you on a landing at all. *The watcher*
+above replaces the whole item. What is still genuinely out of scope is **away-mode**:
+deciding and acting alone while he is gone. You wake, you report, you wait.

--- a/skill/scripts/watch-runs.ps1
+++ b/skill/scripts/watch-runs.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+  Frozen watcher. Emits one line per centurion event - landed, errored, gone quiet -
+  so Caesar is woken by the harness instead of waiting to be asked.
+
+.DESCRIPTION
+  Frozen for the reason the spawn and the sweep are: correctness IS the filter set.
+  A watcher that greps only for the success marker is silent through a wedge, a
+  crash and a budget kill, and silence is indistinguishable from "still working" -
+  which is the exact failure this script exists to end.
+
+  spawn-ticket-agent.ps1 detaches (Start-Process, no wait), so a landed centurion
+  reaches nothing: no SubagentStop, no background-task completion, no entry in
+  `claude agents`. Caesar's only wake was Raj typing, and nothing obliged a poll on
+  that turn. Hence "Harvest. As centurions land" described an event Caesar could
+  not observe.
+
+  Drive it from the Monitor tool, persistent, one per session:
+    Monitor(command: 'powershell -NoProfile -ExecutionPolicy Bypass -File
+            <this> -RepoPath <repo>', persistent: true)
+  Each stdout line becomes one notification, and a notification lands even while
+  Caesar sits idle mid-grill. SKILL.md decides what he says about it.
+
+  Emits no verdict, the same as inspect-run.ps1. LANDED is not "accept the gist"
+  and QUIET is not "kill it" - SKILL.md's failure table makes both calls.
+
+.EXAMPLE
+  .\watch-runs.ps1 -RepoPath C:\Users\rajdh\Projects\caesar
+  .\watch-runs.ps1 -RepoPath . -Once      # one pass, for the smoke test
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'Watch')][string]$RepoPath,
+    [Parameter(Mandatory = $true, ParameterSetName = 'SelfTest')][switch]$SelfTest,
+    [int]$QuietMinutes = 30,
+    [int]$RecheckMinutes = 15,
+    [int]$PollSeconds = 20,
+    [switch]$Once
+)
+
+$ErrorActionPreference = 'Stop'
+
+$logDir = if ($RepoPath) { Join-Path $RepoPath '.claude\caesar-runs' }   # unset under -SelfTest
+$reported = @{}
+
+function Emit([string]$Line) {
+    # Voice off: these lines are judged, and a grid is scanned (SKILL.md, "Where the
+    # voice is on"). Flush explicitly - a buffered line is a notification that never
+    # arrives, which is the bug this script is fixing.
+    Write-Output $Line
+    [Console]::Out.Flush()
+}
+
+# The only progress signal a running centurion has: `claude -p` writes its result JSON
+# once, at the very end, but the transcript .jsonl mtime advances while it works.
+# Derivation lifted from inspect-run.ps1 so both read the same heartbeat.
+function Get-HeartbeatAge([string]$WorktreeName) {
+    $wt = Join-Path $RepoPath ".claude\worktrees\$WorktreeName"
+    $dir = Join-Path "$env:USERPROFILE\.claude\projects" ($wt -replace '[:\\/.]', '-')
+    if (-not (Test-Path $dir)) { return $null }
+    $t = Get-ChildItem $dir -Filter *.jsonl -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime | Select-Object -Last 1
+    if (-not $t) { return $null }
+    ((Get-Date) - $t.LastWriteTime).TotalMinutes
+}
+
+function Invoke-Pass([bool]$Silent) {
+    if (-not (Test-Path $logDir)) { return }
+    foreach ($f in Get-ChildItem $logDir -Filter *.json -File -ErrorAction SilentlyContinue) {
+        if ($reported[$f.Name] -eq 'done') { continue }
+        $name = $f.BaseName -replace '-\d{8}-\d{6}$', ''
+
+        # 0 bytes is the normal running state: redirection creates the file at spawn.
+        if ($f.Length -gt 0) {
+            $r = $null
+            try { $r = Get-Content -Raw -LiteralPath $f.FullName | ConvertFrom-Json } catch { continue }
+            $reported[$f.Name] = 'done'
+            if ($Silent) { continue }   # backfill, see below
+            if ($r.is_error) {
+                Emit "ERRORED $name  terminal_reason=$($r.terminal_reason) cost=$([math]::Round($r.total_cost_usd,2)) -- inspect-run.ps1 -ResultFile '$($f.FullName)'"
+                continue
+            }
+            $gist = @($r.result -split "`r?`n") | Where-Object { $_ -match '^\s*GIST:\s' } | Select-Object -First 1
+            if ($gist) { Emit "LANDED $name  $($gist.Trim())" }
+            else { Emit "LANDED-NO-GIST $name  exit clean but printed no GIST line -- verify the ticket before appending anything" }
+            continue
+        }
+
+        if ($Silent) { continue }
+
+        # Still running. Quiet is not dead and not a flag - SKILL.md: at 30 minutes you
+        # look, you do not kill. Re-emit each RecheckMinutes so a long wedge cannot go
+        # quiet again after one notice.
+        $age = Get-HeartbeatAge $name
+        if ($null -eq $age) {
+            $age = ((Get-Date) - $f.CreationTime).TotalMinutes
+            if ($age -gt $QuietMinutes) {
+                $bucket = [math]::Floor($age / $RecheckMinutes)
+                if ($reported[$f.Name] -ne "nostart:$bucket") {
+                    $reported[$f.Name] = "nostart:$bucket"
+                    Emit "NO-TRANSCRIPT $name  $([int]$age)m since spawn and the session never wrote a turn -- it may never have started"
+                }
+            }
+            continue
+        }
+        if ($age -gt $QuietMinutes) {
+            $bucket = [math]::Floor($age / $RecheckMinutes)
+            if ($reported[$f.Name] -ne "quiet:$bucket") {
+                $reported[$f.Name] = "quiet:$bucket"
+                Emit "QUIET $name  no transcript write for $([int]$age)m -- look, do not kill: inspect-run.ps1 -ResultFile '$($f.FullName)'"
+            }
+        }
+    }
+}
+
+# Backfill: mark everything already finished as reported, silently. Without this a
+# watcher armed (or re-armed) mid-session replays every centurion the map ever ran as
+# fresh landings, and a false landing is worse than a missed one - Caesar would append
+# a gist to the map twice.
+# One runnable check on the classifier, which is the whole point of the file. Fakes the
+# three states against a temp dir and asserts each is named. It cannot cover the wake
+# itself - that is the Monitor tool's, and is proved by dogfooding.
+if ($SelfTest) {
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "watch-runs-selftest-$(Get-Random)"
+    $runs = New-Item -ItemType Directory -Force -Path (Join-Path $tmp '.claude\caesar-runs')
+    try {
+        '{"is_error":false,"result":"worked\nGIST: a judgeable sentence."}' |
+            Set-Content -LiteralPath (Join-Path $runs 'ticket-1-aaa-20260101-000000.json')
+        '{"is_error":true,"terminal_reason":"budget","total_cost_usd":2.0}' |
+            Set-Content -LiteralPath (Join-Path $runs 'ticket-2-bbb-20260101-000000.json')
+        '{"is_error":false,"result":"talked, did nothing"}' |
+            Set-Content -LiteralPath (Join-Path $runs 'ticket-3-ccc-20260101-000000.json')
+        $never = Join-Path $runs 'ticket-4-ddd-20260101-000000.json'
+        New-Item -ItemType File -Path $never | Out-Null
+        (Get-Item $never).CreationTime = (Get-Date).AddMinutes(-($QuietMinutes + 10))
+
+        $out = & $PSCommandPath -RepoPath $tmp -Once
+        $want = @(
+            @{ Pattern = '^LANDED ticket-1-aaa\s+GIST: a judgeable sentence\.$'; Name = 'landed with gist' }
+            @{ Pattern = '^ERRORED ticket-2-bbb\s+terminal_reason=budget'; Name = 'errored' }
+            @{ Pattern = '^LANDED-NO-GIST ticket-3-ccc'; Name = 'clean exit, no GIST' }
+            @{ Pattern = '^NO-TRANSCRIPT ticket-4-ddd'; Name = 'never started' }
+        )
+        $fail = 0
+        foreach ($w in $want) {
+            if ($out -match $w.Pattern) { Write-Output "  ok   $($w.Name)" }
+            else { Write-Output "  FAIL $($w.Name)"; $fail++ }
+        }
+        if ($out.Count -ne $want.Count) { Write-Output "  FAIL expected $($want.Count) lines, got $($out.Count)"; $fail++ }
+        Write-Output ''
+        Write-Output $(if ($fail) { "SELFTEST FAILED ($fail)" } else { 'SELFTEST PASSED' })
+        if ($fail) { exit 1 }
+    } finally { Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue }
+    return
+}
+
+# -Once skips the backfill: a one-shot diagnostic pass is asked to report what is there,
+# not to suppress it.
+if ($Once) { Invoke-Pass $false; return }
+
+Invoke-Pass $true
+while ($true) {
+    Invoke-Pass $false
+    Start-Sleep -Seconds $PollSeconds
+}


### PR DESCRIPTION
## What changed

New frozen `skill/scripts/watch-runs.ps1`, driven by the Monitor tool, one watcher per session. Emits one line per centurion event: `LANDED` (carrying the `GIST:`), `LANDED-NO-GIST`, `ERRORED`, `QUIET`, `NO-TRANSCRIPT`. SKILL.md wired to it in five places.

## Why

Fixes the reported behaviour: a scout finishes and Caesar says nothing until Raj asks for status.

`spawn-ticket-agent.ps1` fires via `Start-Process` and returns immediately, so the centurion is a detached OS process — not a subagent, not a `claude --bg` session. Nothing in the harness knows it exists: no `SubagentStop`, no background-task completion notification, no entry in `claude agents`, and no hook watching `.claude/caesar-runs/`. An interactive session only gets a turn when something hands it one, and a landing handed Caesar nothing.

Two causes, both real:

1. **Structural.** No wake signal exists. If Raj says nothing, Caesar never finds out.
2. **Behavioural.** On a turn he does get, nothing obliged a poll — `SKILL.md` step 4 said *"Harvest. As centurions land"*, phrasing an event he cannot observe. Hence the intermittency.

Same root cause left the 30-minute timer (`SKILL.md`, *The timer: look, do not kill*) with no clock, so it had never fired either. The watcher gives it one.

## Proof it ran

- **Wake mechanism, live on native Windows.** Armed a Monitor over a PowerShell filter and fired three simulated scouts. All three delivered as notifications: `LANDED … :: GIST: …`, `WEDGED? … no write for 16s`, `ERRORED …`. This is the load-bearing unknown — issue #2 flagged several Windows behaviours unverified — and it is now verified rather than inherited.
- **Classifier.** `watch-runs.ps1 -SelfTest` fakes the four terminal states against a temp dir and asserts each is named. Passes; parse-clean.
- **Not yet dogfooded on a real map.** No live centurion has woken a real session through this path. Per this repo's own gate, that escalates to a line-by-line read — hence draft.

## Riskiest hunks

- `skill/scripts/watch-runs.ps1:135` — the silent backfill. If it under-marks, a re-armed watcher replays old landings as fresh and Caesar double-appends a gist to the map. A false landing is worse than a missed one, which is why it exists at all.
- `skill/scripts/watch-runs.ps1:63` — heartbeat path derivation, copied from `inspect-run.ps1:90`. If the transcript directory naming ever changes, `QUIET` degrades to `NO-TRANSCRIPT` and misreports a healthy long run as never started.

## Blast radius

Additive and fully revertable. `spawn-ticket-agent.ps1` is untouched; the watcher only reads `.claude/caesar-runs/` and `~/.claude/projects/`, writes nothing, and returns no verdict — every retry/flag/kill decision stays in SKILL.md's failure table. Worst case if the watcher is wrong is a spurious or missing notification, which is the status quo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
