### PR TITLE
fix(watcher): ignore the .dispatch.json sidecar so dispatches stop emitting phantom landings

### DIFF
--- a/skill/scripts/watch-runs.ps1
+++ b/skill/scripts/watch-runs.ps1
@@ -66,7 +66,12 @@ function Get-HeartbeatAge([string]$WorktreeName) {
 
 function Invoke-Pass([bool]$Silent) {
     if (-not (Test-Path $logDir)) { return }
-    foreach ($f in Get-ChildItem $logDir -Filter *.json -File -ErrorAction SilentlyContinue) {
+    # *.dispatch.json is the tier/model/effort sidecar written at spawn time (#52). It is
+    # not a run result and never carries a GIST, so without this exclusion every single
+    # dispatch emits a phantom LANDED-NO-GIST the moment it starts.
+    $runFiles = Get-ChildItem $logDir -Filter *.json -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -notlike '*.dispatch.json' }
+    foreach ($f in $runFiles) {
         if ($reported[$f.Name] -eq 'done') { continue }
         $name = $f.BaseName -replace '-\d{8}-\d{6}$', ''
 


### PR DESCRIPTION
#52 added a .dispatch.json sidecar beside each run's result file. watch-runs.ps1 globs *.json in that directory, so it reads every sidecar as a completed run with no GIST line — a phantom LANDED-NO-GIST for every dispatch, at spawn time, forever. Observed twice within a minute on #53 and #64, the first two tiered dispatches. Fix excludes *.dispatch.json from the glob. Filter verified in isolation; script still parses. Refs #52, #62.