### PR TITLE
fix(skill): reference Wayfinder by name, unbreak doc links (#90)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -14,9 +14,25 @@ AFK tickets yourself by dispatching centurions, and interrupting him only for th
 types that genuinely need a human. (**Centurion** is a spawned agent, **scout** one sent on
 a research ticket — see *Voice* below.)
 
-Read `C:\Users\rajdh\.claude\skills\wayfinder\SKILL.md` for the map format and ticket
-semantics. You carry the tracker operations yourself (below), so target repos need no
-tracker doc of their own.
+Read the **`wayfinder`** skill's own `SKILL.md` for the map format and ticket semantics.
+Resolve it **by name, never by path**. Wayfinder sets `disable-model-invocation: true`, so
+the Skill tool refuses it — ask the harness where its plugin is installed instead:
+
+```powershell
+claude plugin list --json | ConvertFrom-Json |
+  ForEach-Object { Join-Path $_.installPath 'skills\wayfinder\SKILL.md' } |
+  Where-Object { Test-Path $_ }
+```
+
+`installPath` is the version the harness is actually using. Never write a literal path to
+Wayfinder and never glob the plugin cache: cache paths carry a version segment and old
+version directories are never removed, so a literal either breaks on the next upstream
+release or — worse, and silently — keeps resolving to a frozen copy while you believe you
+are reading current Wayfinder. If the command returns nothing, Wayfinder is not installed;
+say so rather than guessing at a path.
+
+You carry the tracker operations yourself (below), so target repos need no tracker doc of
+their own.
 
 ## Invocation and roles
 
@@ -256,7 +272,7 @@ overridable per-map in the map's own **Notes** section.
 
 A centurion inherits everything an interactive session has: both `CLAUDE.md` files, the
 full skill list, the user-level SessionStart hooks. `--worktree` changes only the working
-directory ([#72](../docs/research/headless-inheritance.md), four probes through the real
+directory ([#72](https://github.com/Dhillvn/caesar/blob/main/docs/research/headless-inheritance.md), four probes through the real
 spawn path). So the skill block is an **override layer, not a re-listing** — naming a
 skill the agent already holds is dead weight in every dispatch. Three rules, in order:
 
@@ -269,7 +285,7 @@ whether `ponytail` changes a headless agent's output at all has never been measu
 **2. Never retype an exclusion — the spawn script carries them.** The one banned skill is
 `claude-api`, and the ban lives in the guardrail heredoc in
 `scripts/spawn-ticket-agent.ps1`, where it reaches every centurion and cannot be
-forgotten. **Ban nothing else.** [#73](../docs/research/skill-cost-inventory.md) measured
+forgotten. **Ban nothing else.** [#73](https://github.com/Dhillvn/caesar/blob/main/docs/research/skill-cost-inventory.md) measured
 all 119 `SKILL.md` files on the machine against several hundred real loads: `SKILL.md`
 size predicts injection at 0.94×, directory size does not predict it at all, and the
 largest ordinary skill is 45 KB — about 6% of the $5.00 cap. `claude-api` injects 898 KB
@@ -280,8 +296,9 @@ skill" banned cheap skills for nothing and is retired.
 
 For a *new* skill, the test is structural, not size: no `SKILL.md` in its directory, or
 observed injection ≈ its whole directory size. Threshold **100 KB injected**. Re-run
-`scripts/skill_cost.py` after a Claude Code upgrade — `claude-api`'s bundle grew 799 KB →
-898 KB in one patch release. Only Raj adds to the ban; a centurion that wants a banned
+[`scripts/skill_cost.py`](https://github.com/Dhillvn/caesar/blob/main/scripts/skill_cost.py)
+(the Caesar repo's own `scripts/`, not this skill's) after a Claude Code upgrade:
+`claude-api`'s bundle grew 799 KB → 898 KB in one patch release. Only Raj adds to the ban; a centurion that wants a banned
 skill reads its files off disk.
 
 **3. Name only what the ticket needs and the agent would not reach for.** This is the
@@ -295,7 +312,7 @@ per-ticket judgment and the only part you write by hand — one line, no rationa
 | research past ~5 sources | **nothing — read the sources directly** |
 
 **The NotebookLM expectation is retired, not forgotten.**
-[#74](../docs/research/notebooklm-headless.md) measured it from inside a real centurion:
+[#74](https://github.com/Dhillvn/caesar/blob/main/docs/research/notebooklm-headless.md) measured it from inside a real centurion:
 query and ingest are both programmatically capable and neither is blocked by the deny
 list, but both ride browser cookies Google expires server-side (~10 days observed),
 renewable only by a human signing into a Chromium window — `auth refresh` cannot do it
@@ -348,7 +365,7 @@ Caesar itself, the hardest role on the machine, at Opus medium and finds it suff
 Published high-effort wins are measured on hard benchmark tasks, not on deliberately
 bite-sized tickets. Holding effort at medium also keeps the rubric to one live dial.
 
-[#64](../docs/research/sonnet-low-reps.md) measured Sonnet-low as 8.8–15.4% cheaper than
+[#64](https://github.com/Dhillvn/caesar/blob/main/docs/research/sonnet-low-reps.md) measured Sonnet-low as 8.8–15.4% cheaper than
 Opus-low at identical (100%) grade, and proposed dropping Execute to `low`. **Raj held it
 at `medium`** on 2026-08-05: the fixtures were sub-$0.45 toy cells against real tickets at
 $1.58–$2.85, so the saving is unproven at working length, and one live dial is worth more


### PR DESCRIPTION
Closes #90. Repo-side half of the plugin cutover; the machine-side half stays with #88. The plugin is **not** installed and this PR does not assume it is.

## 1. What changed

Three path fixes in `skill/SKILL.md`, exactly the three the #87 review named. No prose about Wayfinder's semantics changed — #87 found all six of Caesar's claims still true at v1.2.2.

**a. `skill/SKILL.md:17` — the hardcoded Wayfinder path, replaced by a name-based lookup.**

Before:

```
Read `C:\Users\rajdh\.claude\skills\wayfinder\SKILL.md` for the map format and ticket
semantics.
```

After:

```
Read the **`wayfinder`** skill's own `SKILL.md` for the map format and ticket semantics.
Resolve it **by name, never by path**. Wayfinder sets `disable-model-invocation: true`, so
the Skill tool refuses it — ask the harness where its plugin is installed instead:

    claude plugin list --json | ConvertFrom-Json |
      ForEach-Object { Join-Path $_.installPath 'skills\wayfinder\SKILL.md' } |
      Where-Object { Test-Path $_ }

`installPath` is the version the harness is actually using. Never write a literal path to
Wayfinder and never glob the plugin cache: [...] If the command returns nothing, Wayfinder
is not installed; say so rather than guessing at a path.
```

**Why this mechanism and not the Skill tool.** The obvious name-based reference — "invoke the `wayfinder` skill via the Skill tool" — does not work, and I confirmed that by trying it rather than reasoning about it:

```
Skill wayfinder cannot be used with Skill tool due to disable-model-invocation.
Ask the user to run /wayfinder themselves — it cannot be invoked via the Skill tool.
Do not replicate this skill's workflow by other means — it is reserved for explicit
user invocation.
```

`wayfinder/SKILL.md` carries `disable-model-invocation: true` in its frontmatter, and `wayfinder` is correspondingly absent from the model-visible skill list. So a Skill-tool instruction at line 17 would have shipped an instruction that always errors.

`claude plugin list --json` is the remaining name-based route, and it satisfies the ticket's hard constraint: the pipeline writes **no version segment** and does **no globbing of the cache**. It asks the harness which install is live and takes the `installPath` the harness reports, so an upstream release moves the answer automatically instead of breaking it or silently freezing it. It is also plugin-id-agnostic — it does not hardcode `mattpocock-skills`, so it survives Wayfinder being repackaged.

**b. Four junction-dependent `../docs/research/*.md` links → absolute GitHub blob URLs**, at lines 259, 272, 298 and 351 in the pre-edit file: `headless-inheritance.md` (#72), `skill-cost-inventory.md` (#73), `notebooklm-headless.md` (#74), `sonnet-low-reps.md` (#64). These resolved only because `~\.claude\skills\caesar` is a junction into this repo, which makes `..` reach the repo root. A plugin install that copies `skill/` without `docs/` breaks all four.

**c. `skill/SKILL.md:283` — `scripts/skill_cost.py`.** Already broken before this map: the file is at the repo root `scripts/`, while the other nine `scripts/*` references in this file mean the skill's own `scripts/`. Now an absolute URL, with the distinction stated inline.

## 2. Why

Ticket #90, split out of #88, acting on the verdict of #87 ("path change" — Caesar's content is still true, its paths are not). Under a plugin install Caesar's single pointer at its own upstream spec dead-ends, and the doc links go with it.

## 3. Proof it ran

Before/after of each edited line is in section 1 and in the diff. Greps over the whole repo, on this branch:

```
$ git grep -n -F 'skills\wayfinder'
skill/SKILL.md:23:  ForEach-Object { Join-Path $_.installPath 'skills\wayfinder\SKILL.md' } |
```

The single surviving hit is the *relative* fragment inside the resolver, appended to whatever `installPath` the harness reports. It is not a path to anywhere on its own and contains no version segment.

```
$ git grep -n -F '.claude\skills'
README.md:11:Junctions `~\.claude\skills\caesar` onto `skill\` in this repo. No admin needed, no
install.ps1:22:    [string]$LinkPath = (Join-Path $env:USERPROFILE '.claude\skills\caesar'),
```

Both are Caesar's **own** junction install mechanism, not Wayfinder. Retiring them is #88's job (its items 5 and 6); doing it here would break the install path while the plugin is still uninstalled.

```
$ git grep -n -F '../docs/research'
(no matches, exit 1)
```

The resolver itself was executed on this machine, with the plugin uninstalled:

```
$ powershell -NoProfile -Command "claude plugin list --json | ConvertFrom-Json | ForEach-Object { Join-Path $_.installPath 'skills\wayfinder\SKILL.md' } | Where-Object { Test-Path $_ }"
(no output, exit 0)
```

Correct behaviour for today's state — it returns nothing and errors on nothing, which is the branch the prose tells the reader to report rather than guess past. It cannot be proven to return the right path until #88 installs the plugin; that verification belongs to #88.

## 4. Riskiest hunks

1. **`skill/SKILL.md:17-31`** — the resolver. Its shape is unverified against a real `mattpocock-skills` install: I confirmed `claude plugin list --json` emits `installPath` (against the `caveman`, `ponytail` and `claude-plugins-official` entries) but not that Wayfinder sits at `skills\wayfinder\SKILL.md` beneath it. If the plugin nests skills differently, the `Test-Path` filter yields nothing and Caesar reports "not installed" — a wrong-but-loud failure, which is the failure mode the ticket asked for over a silent stale read. #88 should check the subpath as it installs.
2. **`skill/SKILL.md:296-299`** — the `skill_cost.py` URL is `blob/main`, so it 404s until this branch merges, and it tracks `main` rather than a pinned ref. The same applies to the four research links.

## 5. Blast radius and revertability

One file, `skill/SKILL.md`, prose only. No script, no behaviour, no interface. Nothing outside the repo was written; `~\.claude\skills\`, `settings.json` and the plugin cache were read only. Because `~\.claude\skills\caesar` is a junction into `skill/`, merging this changes the live installed Caesar the moment it lands on `main` — that is the intent, and the mirror #88 syncs stays consistent.

Fully revertable: `git revert` of a single commit restores the previous text exactly. The worst case after a revert is Caesar reading the pre-cutover hardcoded path, which still resolves today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
