### PR TITLE
fix(spawn-ticket-agent): resolve -RepoPath through git before use

### DIFF
--- a/skill/scripts/spawn-ticket-agent.ps1
+++ b/skill/scripts/spawn-ticket-agent.ps1
@@ -47,6 +47,18 @@ $tierFlags = @{
 if ($TicketUrl -notmatch '/issues/(\d+)') { throw "Not a GitHub issue URL: $TicketUrl" }
 $ticketNumber = $Matches[1]
 if (-not (Test-Path (Join-Path $RepoPath '.git'))) { throw "Not a git repo: $RepoPath" }
+
+# Resolve through git's own idea of the path, not the caller's string (#93). Windows
+# treats a casing/alias mismatch (C:\...\Caesar vs C:\...\caesar) as the same directory;
+# git does not, and Claude Code's worktree isolation check trusts git. git prints
+# forward slashes on Windows too - convert to the backslash form the rest of this
+# script (Join-Path, -WorkingDirectory) expects.
+$canonicalRepoPath = git -C $RepoPath rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0 -or -not $canonicalRepoPath) {
+    throw "git could not resolve repo path: $RepoPath"
+}
+$RepoPath = $canonicalRepoPath -replace '/', '\'
+
 if ($PromptFile) {
     if (-not (Test-Path $PromptFile)) { throw "No prompt file at $PromptFile" }
     $Prompt = Get-Content -Raw -LiteralPath $PromptFile


### PR DESCRIPTION
## What changed
`spawn-ticket-agent.ps1` now resolves `-RepoPath` via `git -C <path> rev-parse --show-toplevel` immediately after the existing `.git` existence check, converts the forward-slash git output to backslash form, and uses that canonical path for everything downstream: `$logDir`, `$WorktreePath`, `-WorkingDirectory`, and the dispatch sidecar. If `rev-parse` fails, the script throws naming the path instead of falling through.

## Why
Links #93. Dispatching #89 with `-RepoPath C:\Users\rajdh\Projects\Caesar` against a repo git records as `C:/Users/rajdh/Projects/caesar` made Claude Code's worktree isolation check refuse to start — Windows treats the two paths as the same directory, git does not. Resolving through git closes that gap structurally instead of relying on callers to pass the exact casing.

## Proof it ran
Nested `claude -p --permission-mode bypassPermissions` dispatch is auto-denied by this session's own permission layer — expected, not chased or retried. Proved the path resolution instead, which is the part that changed:

1. **Direct check** — `git -C "C:\Users\rajdh\Projects\Caesar" rev-parse --show-toplevel` returns `C:/Users/rajdh/Projects/caesar`, confirming the casing mismatch is real and git-detectable.
2. **Through the script (wrong casing)** — ran the script with `-RepoPath C:\Users\rajdh\Projects\Caesar` against scratch ticket Dhillvn/Caesar#95. Both the returned object and the `*.dispatch.json` sidecar carried `WorktreePath`/log paths under the git-canonical lowercase `caesar`, not the caller's `Caesar` string.
3. **No regression (correct casing)** — reran with `-RepoPath C:\Users\rajdh\Projects\caesar`; output identical in shape and canonical path, confirming no behavior change for already-correct input.

Scratch ticket #95 closed, scratch worktrees torn down (`remove-worktree.ps1`; one required a manual `Remove-Item` after git had already deregistered it — the directory held no commits and was outside git's worktree list), scratch run files under `.claude\caesar-runs\` deleted.

## Riskiest hunks
- `skill/scripts/spawn-ticket-agent.ps1:50-58` — the new `git -C $RepoPath rev-parse` call and the reassignment of `$RepoPath`. Everything downstream (log dir, worktree path, dispatch record) now depends on this resolving correctly.
- `skill/scripts/spawn-ticket-agent.ps1:58` — `-replace '/', '\'` on git's output. Confirmed via the proof runs above that the resulting backslash path works correctly with `Join-Path` and `-WorkingDirectory`.

## Blast radius and revertability
Single file, single script (`spawn-ticket-agent.ps1`), 12 lines added, nothing removed. Flag set, deny list, tier table, and guardrail heredoc untouched, as required. Fully revertible with `git revert`; no state or schema changes. Does not touch anything under `C:\Users\rajdh\.claude\`.