### PR TITLE
fix(watcher): report a dead run at once, and only once (#94)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -396,15 +396,21 @@ One watcher covers every centurion on the machine, however many maps dispatched 
 not arm one per ticket. It backfills silently on start, so re-arming after a crash replays
 nothing and cannot double-append a gist to the map.
 
-Five events, and **it returns no verdict** — same as `inspect-run.ps1`:
+Six events, and **it returns no verdict** — same as `inspect-run.ps1`:
 
 | Event | What it means |
 |---|---|
 | `LANDED` | result JSON parsed, `GIST:` line carried on the event — verify, then append |
 | `LANDED-NO-GIST` | exit clean, no `GIST:` printed — verify the ticket before appending anything |
 | `ERRORED` | `is_error: true`, with `terminal_reason` and cost |
+| `DIED-AT-SPAWN` | the dispatched process is **gone**, its result file empty, no turn ever written — it definitely never started, and the stderr tail is on the event. Off the clock: it arrives on the next poll |
 | `QUIET` | transcript has not advanced past the timer — **look, do not kill** |
-| `NO-TRANSCRIPT` | past the timer and the session never wrote a turn — it may never have started |
+| `NO-TRANSCRIPT` | past the timer and the session never wrote a turn — it *may* never have started |
+
+`DIED-AT-SPAWN` and `NO-TRANSCRIPT` differ in certainty, and that is the whole distinction:
+the first read the PID from the dispatch sidecar and found nothing alive, so the run is
+terminal and is reported **once**. The second only knows the clock ran out, so it re-arrives
+every `-RecheckMinutes` — the process may yet be alive.
 
 `LANDED` is not "accept the gist" and `QUIET` is not "kill it". The failure table below
 makes both calls, unchanged.
@@ -441,6 +447,7 @@ call is yours, here:
 | **Budget exhausted** — cost at cap, no artifact | **Flag.** Raising the cap or splitting the ticket is Raj's call |
 | **Silent do-nothing** — exit 0, `is_error: false`, ticket open, no comment. Includes the clean-exit-mid-wait shape: the centurion built its rig, backgrounded the work, and ended its turn saying it is waiting for a completion notification — nothing wakes a headless agent, so the work finishes after it is gone and is thrown away | **Retry**, prompt sharpened to name the missing artifact |
 | **Half-done** — comment but not closed, or closed with no comment | **Neither.** Finish the mechanical remainder yourself, no spawn. Flag only if the *work* is partial rather than the bookkeeping |
+| **Died at spawn** — `DIED-AT-SPAWN`: the process is gone, nothing was ever written, stderr tail on the event | **Read the tail.** It is the whole diagnosis, and it is nearly always the environment refusing — worktree taken, path missing, auth. Fix the environment and **retry**; if nothing on this machine can be fixed, **flag** |
 | **Wedged** — killed after the heartbeat flatlined | **Triage on the tails.** Died mid-API-call → bad roll → retry. Looping the same action → wall → flag. Never really started (auth, bad path) → wall → flag |
 | **Coherently wrong** — artifact complete, answer collides with a prior decision | **Reopen, comment what it collides with, flag. Never retry** — *except* a complete-but-inadequate artifact at **Execute**, which retries **once at Heavy** |
 
@@ -482,6 +489,12 @@ legitimately slow work, and `--max-budget-usd` already bounds a runaway. Both in
 
 A wedge is not automatically a flag — a dropped connection is a bad roll, a loop is a
 wall, and the table above already tells them apart.
+
+**A death is not on the clock at all.** A run whose process is gone before it wrote a turn
+is finished, not slow, so `DIED-AT-SPAWN` arrives on the next poll — seconds, not 30
+minutes — and arrives exactly **once**, because a corpse's state cannot change and a
+repeated alarm on it is how a real landing gets missed. Nothing acknowledges it and nothing
+needs to: re-arming the watcher backfills it silently, the same as a landing.
 
 ### Retry mechanics
 

--- a/skill/scripts/watch-runs.ps1
+++ b/skill/scripts/watch-runs.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
-  Frozen watcher. Emits one line per centurion event - landed, errored, gone quiet -
-  so Caesar is woken by the harness instead of waiting to be asked.
+  Frozen watcher. Emits one line per centurion event - landed, errored, died at spawn,
+  gone quiet - so Caesar is woken by the harness instead of waiting to be asked.
 
 .DESCRIPTION
   Frozen for the reason the spawn and the sweep are: correctness IS the filter set.
@@ -35,7 +35,11 @@ param(
     [int]$QuietMinutes = 30,
     [int]$RecheckMinutes = 15,
     [int]$PollSeconds = 20,
-    [switch]$Once
+    [switch]$Once,
+    # -Once -Rearm reproduces exactly what the persistent watcher does when it starts:
+    # one silent backfill pass, then one reporting pass. Only the self-test uses it,
+    # to prove a re-arm replays nothing.
+    [switch]$Rearm
 )
 
 $ErrorActionPreference = 'Stop'
@@ -91,6 +95,36 @@ function Invoke-Pass([bool]$Silent) {
             continue
         }
 
+        # Dead PID + empty result + no transcript is not "quiet", it is finished and
+        # failed, and it is knowable on the next poll instead of at the 30m timer (#94).
+        # This sits ABOVE the -Silent bail on purpose: a re-armed watcher must adopt a
+        # dead run as already-reported exactly as it adopts a landing, otherwise the
+        # same corpse re-alarms every RecheckMinutes forever (#94 defect B).
+        # PID reuse can only make a dead run look alive, never the reverse, and that
+        # falls back to the old NO-TRANSCRIPT path - so no start-time check.
+        $dispatchFile = $f.FullName -replace '\.json$', '.dispatch.json'
+        if (Test-Path -LiteralPath $dispatchFile) {
+            $d = $null
+            try { $d = [IO.File]::ReadAllText($dispatchFile) | ConvertFrom-Json } catch { $d = $null }
+            if ($d -and $d.ProcessId -and
+                -not (Get-Process -Id $d.ProcessId -ErrorAction SilentlyContinue) -and
+                $null -eq (Get-HeartbeatAge $name)) {
+                $reported[$f.Name] = 'done'
+                if ($Silent) { continue }
+                # One event = one notification line, so the tail is the last non-empty
+                # stderr line with its whitespace collapsed, never the raw block.
+                $tail = 'stderr empty'
+                if ($d.StderrFile -and (Test-Path -LiteralPath $d.StderrFile)) {
+                    $last = @(Get-Content -LiteralPath $d.StderrFile -Tail 40 -ErrorAction SilentlyContinue) |
+                        Where-Object { $_.Trim() } | Select-Object -Last 1
+                    if ($last) { $tail = 'stderr: ' + ($last.Trim() -replace '\s+', ' ') }
+                }
+                if ($tail.Length -gt 200) { $tail = $tail.Substring(0, 200) + '...' }
+                Emit "DIED-AT-SPAWN $name  pid $($d.ProcessId) is gone, result file empty, session never wrote a turn -- $tail"
+                continue
+            }
+        }
+
         if ($Silent) { continue }
 
         # Still running. Quiet is not dead and not a flag - SKILL.md: at 30 minutes you
@@ -139,12 +173,45 @@ if ($SelfTest) {
         New-Item -ItemType File -Path $never | Out-Null
         (Get-Item $never).CreationTime = (Get-Date).AddMinutes(-($QuietMinutes + 10))
 
+        # A PID nothing owns. Probed rather than assumed - a hardcoded number is a test
+        # that passes for the wrong reason the day something happens to hold it.
+        $deadPid = 1
+        do { $deadPid = Get-Random -Minimum 100000 -Maximum 999999 }
+        while (Get-Process -Id $deadPid -ErrorAction SilentlyContinue)
+
+        # Sidecars go in BOM-less, the same way spawn-ticket-agent.ps1 writes them:
+        # PS 5.1's `Set-Content -Encoding UTF8` prepends EF BB BF and ConvertFrom-Json
+        # over [IO.File]::ReadAllText then dies on it.
+        function Write-Dispatch($Path, $Object) {
+            [System.IO.File]::WriteAllText($Path, ($Object | ConvertTo-Json),
+                (New-Object System.Text.UTF8Encoding $false))
+        }
+
+        # Defect A: died in the first second. Deliberately NOT aged past the quiet timer -
+        # if this only fires because the clock ran, the fix did nothing.
+        $died = Join-Path $runs 'ticket-5-eee-20260101-000000.json'
+        New-Item -ItemType File -Path $died | Out-Null
+        $diedErr = Join-Path $runs 'ticket-5-eee-20260101-000000.err'
+        Set-Content -LiteralPath $diedErr -Value @('', 'fatal: worktree creation refused')
+        Write-Dispatch (Join-Path $runs 'ticket-5-eee-20260101-000000.dispatch.json') @{
+            ProcessId = $deadPid; StderrFile = $diedErr }
+
+        # A live PID with an empty result is still running, whatever the clock says. It
+        # must keep the old NO-TRANSCRIPT wording and never be called dead.
+        $live = Join-Path $runs 'ticket-6-fff-20260101-000000.json'
+        New-Item -ItemType File -Path $live | Out-Null
+        (Get-Item $live).CreationTime = (Get-Date).AddMinutes(-($QuietMinutes + 10))
+        Write-Dispatch (Join-Path $runs 'ticket-6-fff-20260101-000000.dispatch.json') @{
+            ProcessId = $PID; StderrFile = 'nonexistent.err' }
+
         $out = & $PSCommandPath -RepoPath $tmp -Once
         $want = @(
             @{ Pattern = '^LANDED ticket-1-aaa\s+GIST: a judgeable sentence\.$'; Name = 'landed with gist' }
             @{ Pattern = '^ERRORED ticket-2-bbb\s+terminal_reason=budget'; Name = 'errored' }
             @{ Pattern = '^LANDED-NO-GIST ticket-3-ccc'; Name = 'clean exit, no GIST' }
-            @{ Pattern = '^NO-TRANSCRIPT ticket-4-ddd'; Name = 'never started' }
+            @{ Pattern = '^NO-TRANSCRIPT ticket-4-ddd'; Name = 'never started, no dispatch sidecar' }
+            @{ Pattern = '^DIED-AT-SPAWN ticket-5-eee.+stderr: fatal: worktree creation refused$'; Name = 'died at spawn, reported off the clock with its stderr tail' }
+            @{ Pattern = '^NO-TRANSCRIPT ticket-6-fff'; Name = 'live pid past the timer is quiet, not dead' }
         )
         $fail = 0
         foreach ($w in $want) {
@@ -152,6 +219,20 @@ if ($SelfTest) {
             else { Write-Output "  FAIL $($w.Name)"; $fail++ }
         }
         if ($out.Count -ne $want.Count) { Write-Output "  FAIL expected $($want.Count) lines, got $($out.Count)"; $fail++ }
+
+        # Defect B: a re-armed watcher backfills the corpse silently, same as a landing.
+        # The two timer-driven alarms are not backfilled and must still speak - they
+        # describe runs that are still open, and suppressing those is the missed landing.
+        $rearmOut = @(& $PSCommandPath -RepoPath $tmp -Once -Rearm)
+        $rearmWant = @('^NO-TRANSCRIPT ticket-4-ddd', '^NO-TRANSCRIPT ticket-6-fff')
+        if ($rearmOut -match '^DIED-AT-SPAWN') { Write-Output '  FAIL re-arm re-reports a dead run'; $fail++ }
+        elseif ($rearmOut -match '^LANDED|^ERRORED') { Write-Output '  FAIL re-arm re-reports a landing'; $fail++ }
+        # -not (array -match p), never (array -notmatch p): over an array -notmatch is a
+        # filter, so it returns every OTHER line and reads as a failure on a clean pass.
+        elseif ($rearmOut.Count -ne 2 -or ($rearmWant | Where-Object { -not ($rearmOut -match $_) })) {
+            Write-Output "  FAIL re-arm should say only the two open runs, said: $($rearmOut -join ' | ')"; $fail++
+        }
+        else { Write-Output '  ok   re-arm replays nothing terminal, only the runs still open' }
         Write-Output ''
         Write-Output $(if ($fail) { "SELFTEST FAILED ($fail)" } else { 'SELFTEST PASSED' })
         if ($fail) { exit 1 }
@@ -161,7 +242,11 @@ if ($SelfTest) {
 
 # -Once skips the backfill: a one-shot diagnostic pass is asked to report what is there,
 # not to suppress it.
-if ($Once) { Invoke-Pass $false; return }
+if ($Once) {
+    if ($Rearm) { Invoke-Pass $true }
+    Invoke-Pass $false
+    return
+}
 
 Invoke-Pass $true
 while ($true) {


### PR DESCRIPTION
Closes #94. Two defects, one file's behaviour, plus the `SKILL.md` rows that name the new event. Draft — do not merge.

## 1. What changed

**`skill/scripts/watch-runs.ps1`** — a new terminal event, `DIED-AT-SPAWN`, detected from the dispatch sidecar and reported exactly once.

The classifier now sits between the "result file has bytes" branch and the quiet timer:

```powershell
$dispatchFile = $f.FullName -replace '\.json$', '.dispatch.json'
if (Test-Path -LiteralPath $dispatchFile) {
    $d = $null
    try { $d = [IO.File]::ReadAllText($dispatchFile) | ConvertFrom-Json } catch { $d = $null }
    if ($d -and $d.ProcessId -and
        -not (Get-Process -Id $d.ProcessId -ErrorAction SilentlyContinue) -and
        $null -eq (Get-HeartbeatAge $name)) {
        $reported[$f.Name] = 'done'
        if ($Silent) { continue }
        ...
        Emit "DIED-AT-SPAWN $name  pid $($d.ProcessId) is gone, result file empty, session never wrote a turn -- $tail"
        continue
    }
}
```

Three things about that block are the whole fix:

- **It is off the clock.** Gone PID + 0-byte result + no transcript is decidable on the next poll, so defect A's 30-minute wait becomes ~20 seconds.
- **`$reported[...] = 'done'` before the emit** makes the event terminal, like `LANDED` and `ERRORED`. Defect B's indefinite re-alarm stops because the state genuinely cannot change.
- **It sits ABOVE the `if ($Silent) { continue }` bail**, so the silent backfill now adopts a dead run the same way it already adopted a landing. That is what makes re-arming clear it.

`-Rearm` is a new switch, used only by the self-test: with `-Once` it runs one silent pass then one reporting pass, which is exactly what the persistent watcher does at startup.

**`skill/SKILL.md`** — one row in the watcher event table ("Five events" → "Six events"), one paragraph on how `DIED-AT-SPAWN` differs from `NO-TRANSCRIPT`, one row in the failure table, and one paragraph in the timer section saying a death is not on the clock. Nothing else.

## 1b. The three open questions, answered

**Q1 — new event class, or a faster `NO-TRANSCRIPT`?** *New event class.* The two carry different certainty, and Caesar's action differs accordingly. `NO-TRANSCRIPT` means "the clock ran out and I found no turn" — the process may well be alive, so it re-arrives per `-RecheckMinutes` and Caesar goes and looks. `DIED-AT-SPAWN` means "I checked the PID and there is nothing there" — terminal, reported once, with the stderr tail that is the actual diagnosis. Folding them would force one of two wrong behaviours: either a live run gets a corpse's report-once treatment and a real wedge goes silent after one notice, or a corpse inherits the timer and defects A and B both survive. The cost is one new word in `SKILL.md`, paid in the same PR.

**Q2 — where does resolved-run state live?** *Nowhere new.* The existing in-memory `$reported` hashtable, plus extending the silent backfill to cover terminal-dead runs. The ticket's own framing points here: the backfill already covered landings and just needed to cover never-started runs. A marker file or an `archive\` convention would add a second source of truth to a directory that is already gitignored machine-local scratch, and would have to be cleaned up by something. In-memory dies with the session, which is correct because the watcher is re-armed per session and the re-arm now backfills. `Get-ChildItem` stays non-recursive, so the manual `archive\` escape hatch is untouched.

The accepted cost, stated plainly: a run that dies while no watcher is armed is backfilled silently and never announced. That is the same trade the landing backfill already makes, and the ticket names that property as load-bearing. The ticket stays open and assigned, so `frontier.ps1` and `status.ps1` still surface it — the watcher is not the only channel.

**Q3 — what counts as "dealt with"?** *Process death itself, not a closed ticket.* One report of a terminal state is complete information; there is no acknowledgement step and nothing to acknowledge. Deliberately **not** used as a suppressor: a closed ticket. The ticket flags the case itself — a closed ticket with a wedged process still running is worth not silencing — and querying GitHub per poll would also put the network on the watcher's hot path and make the whole event stream fail when `gh` does. So a live process keeps alarming per `-RecheckMinutes` no matter what the ticket says, which is the conservative direction.

## 2. Why

Both defects were hit live on 2026-08-06. #89's first attempt died in the first second (worktree creation refused) and was reported 30 minutes later, long after it had been diagnosed by hand; the same corpse then re-fired at 30m, 45m and 46m on a run torn down an hour earlier, and the only remedy was moving files into `archive\` by hand. Repeated false alarms are how a real landing gets missed.

## 3. Proof it ran

Staged temp directory only — no real agents were dispatched to manufacture dead runs. The self-test grew from four cases to seven:

```
$ powershell -NoProfile -ExecutionPolicy Bypass -File skill/scripts/watch-runs.ps1 -SelfTest
  ok   landed with gist
  ok   errored
  ok   clean exit, no GIST
  ok   never started, no dispatch sidecar
  ok   died at spawn, reported off the clock with its stderr tail
  ok   live pid past the timer is quiet, not dead
  ok   re-arm replays nothing terminal, only the runs still open

SELFTEST PASSED
$ echo exit=$?
exit=0
```

The three new cases are each aimed at a way the fix could be fake:

- **`ticket-5-eee`** (defect A) is staged with a **current** creation time, so it is nowhere near `-QuietMinutes`. If it only fired because the clock ran, the fix did nothing. Its dispatch sidecar carries a PID probed to be free (`do { Get-Random } while (Get-Process -Id ...)`, never a hardcoded number) and a stderr file whose last non-empty line is `fatal: worktree creation refused`; the assertion is anchored on that tail reaching the event line.
- **`ticket-6-fff`** (the inverse) is a **live** PID (`$PID`) with an empty result aged past the timer. It must still say `NO-TRANSCRIPT`. This is the guard against the new branch swallowing running work.
- **The re-arm case** (defect B) runs the whole staged directory a second time through `-Once -Rearm` and asserts the output is exactly the two timer-driven alarms — no `DIED-AT-SPAWN`, no `LANDED`, no `ERRORED`. That is both halves of the constraint at once: the corpse is backfilled, and the landing still is not double-reported.

One assertion bug was caught and fixed while writing this, and it is the repo's own PowerShell rule again: `$array -notmatch $pattern` is a *filter* returning every non-matching element, not a negation, so a clean pass read as a failure. It is now `-not ($array -match $pattern)`, with the reason in a comment.

## 4. Riskiest hunks

1. **PID reuse.** `Get-Process -Id` alone cannot tell a recycled PID from the original. The failure is one-directional: reuse can only make a dead run look **alive**, never a live run look dead, and a dead run that looks alive simply falls through to the old `NO-TRANSCRIPT` path and is reported at the timer — i.e. today's behaviour. A `StartTime` comparison would close it but the sidecar does not record one, and the failure it prevents is a slower report rather than a wrong one. Noted in a comment at the site.
2. **The silent-backfill hole named in Q2** — a death while no watcher is armed is never announced. Deliberate, argued above, and the same trade landings already make.
3. **Out of scope on purpose:** a dead PID *with* a transcript and an empty result — died mid-run rather than at spawn — still surfaces only as `QUIET` at the timer. Question 1 asked about the no-transcript case and that is what this answers. It is the obvious follow-up if it is hit live.

## 5. Blast radius and revertability

Two files, both under `skill/`. Nothing under `C:\Users\rajdh\.claude\` was written.

**No collision with #91**, which is open against the same `SKILL.md`: that PR edits the top of the file (the Wayfinder reference at ~L17-31) and four doc links at ~L259/272/298/351. This PR's edits are confined to the watcher section (~L399) and the failure-table/timer sections (~L444-490), per the ticket's instruction. The two diffs do not touch a shared line and should merge in either order.

`-QuietMinutes` and `-RecheckMinutes` keep their defaults and their per-map override semantics. `Get-ChildItem` over the run directory is still non-recursive, so `archive\` still works as the manual escape hatch. The only new parameter is `-Rearm`, which is inert unless passed.

Fully revertable: one commit, `git revert` restores the previous classifier exactly. Because `~\.claude\skills\caesar` is a junction into `skill/`, merging changes the live installed Caesar the moment it lands — same as any change in this directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
