### PR TITLE
docs(skill): derive the dispatch-prompt shape as a disclosed reference (#104)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -251,6 +251,9 @@ session skips it. An open, unassigned ticket is unclaimed.
 its own git worktree. The script carries the flag set and the deny list; do not compose
 that command by hand.
 
+**Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
+already carries: [`references/prompt-shape.md`](references/prompt-shape.md).
+
 The centurion **posts its own resolution comment and closes its own ticket**, then prints a
 `GIST:` line. You read only the gist and append it to the map. This keeps your context
 cheap and, more importantly, makes verification real.

--- a/skill/references/prompt-shape.md
+++ b/skill/references/prompt-shape.md
@@ -1,0 +1,83 @@
+# The dispatch-prompt shape
+
+The shape of what you write below the `--- ticket instructions follow ---` marker when you
+dispatch a centurion. Derived once from `writing-for-agents`, so composing a dispatch reads
+this instead of re-deriving it
+([#101](https://github.com/Dhillvn/Caesar/issues/101) rules the derivation is done and does
+not repeat).
+
+## The frame
+
+Above the marker, the guardrail heredoc in `scripts/spawn-ticket-agent.ps1` gives every
+centurion the same **frame**: its ticket URL and role; run synchronously because nothing can
+wake it; the full skill list inherited and free to use, `claude-api` excepted; write only to
+its own ticket and its own branch, never the map body and never another ticket; open a draft
+PR and stop; post the resolution, close the ticket, print a 30–60 word `GIST:` line.
+
+Every one of those is already in the centurion's context when it reads your half. Write them
+again and you have two authorities for one meaning — the thing a **single source of truth**
+forbids — and you inflate them past the ticket's own material on the page.
+
+You write about the frame in one case: to **override** it. A research ticket that ends at a
+pushed branch rather than a PR states that end state and says it replaces the frame's.
+
+## The five parts
+
+In this order. A part with nothing to say is left out; the order of the rest holds.
+
+**1. The job, in one sentence, first line.** What this centurion is for, in the imperative.
+It is the leading line of the prompt and does the same work a skill description does — the
+agent reads it before anything else and reads everything after it in its light.
+
+**2. What only the disk knows.** The facts the ticket cannot carry because they live in the
+working environment: which files are the worked examples and where they actually sit,
+gitignored paths, a sibling branch running in parallel, a method that has already been tried.
+This is the **cache** lever — a prompt earns its length by carrying the lookups the centurion
+cannot cheaply perform, and by leaving the ones it can (a file it will open anyway, a
+`--help` output) to the environment. Give it its own heading when it runs past a paragraph.
+
+**3. `## Steps` — numbered, in execution order.** The primary tier of the information
+hierarchy is *what the agent does, in order*. A ticket with a real sequence — fetch the
+proposal, read the section, rewrite it, cite the finding, rename the branch, open the PR —
+written as flat prose leaves the ordering to the centurion's inference, which is a variance
+bug you can fix by typing numbers. Each step names its object: the file by path, the section
+by heading, the branch by name.
+
+**4. `## Done when` — the bound, carried here.** The prompt **stands alone**: a centurion
+that never runs `gh issue view` still finishes correctly and still knows when to stop.
+Pointing at the ticket for the completion criterion is progressive disclosure applied
+backwards — the one element that must never be missed made the one element that is fetched,
+and a skipped or truncated call leaves the run with no bound at all.
+
+Make the criterion **checkable and exhaustive**: a state a `git diff` or a `gh` read settles,
+covering every artifact the ticket produces. *"A `git diff` against `main` touches
+`skill/SKILL.md` and nothing else"* is the form; *"the section reads well"* is not. Where the
+deliverable is a PR, name the five things the merge gate wants (`SKILL.md`, *Build work and
+the merge gate*) in the prompt — the centurion cannot see `SKILL.md`.
+
+This part is also the Execute gate. A ticket you can write step 3 and step 4 for is Execute;
+one you cannot is Heavy.
+
+**5. `## Constraints` — what stays untouched, and the blast radius.** Files and sections the
+run leaves alone, and the reason where the reason is load-bearing (a parallel branch, a
+junction into the live skill, an artifact with no revision history). State each one once. If
+the ticket already carries a constraint, either point at the ticket or write the constraint —
+doing both is the duplication to remove, and writing it is usually right, because part 4 has
+already committed to a prompt that stands alone.
+
+## Prompt the positive
+
+State the target behaviour, so the behaviour you do not want is never named. Steering by
+prohibition drags the forbidden thing into context and makes it *more* available, and the
+negation is a weak modifier over a strongly activated concept.
+
+- *do not rule from the name alone* → **read each skill's own frontmatter and description
+  before ruling on it**
+- *do not fix anything* → **the deliverable is the artifact; the map's later task ticket
+  applies the fix**
+- *do not assume from the name* → **check the frontmatter**
+
+A prohibition earns its place only as a hard guardrail with no positive phrasing — the live
+example being *do NOT pass `--permission-mode bypassPermissions` to a nested `claude -p`*,
+where the flag must be named to be avoided. Pair it with the positive target in the same
+breath: *drop the flag and the nested call goes through*.


### PR DESCRIPTION
## What changed

Two files.

- **New `skill/references/prompt-shape.md`** — the shape Caesar composes a dispatch prompt to, below the `--- ticket instructions follow ---` marker. Four sections: what the guardrail **frame** already carries (so the ticket half never restates it), the five ordered parts of the prompt, the completion criterion, and positive phrasing.
- **`skill/SKILL.md` +3 lines** — one pointer in `## Dispatching a centurion`, front-loading *Composing a dispatch prompt* as the trigger branch. Nothing else in the file is touched.

## Why

Closes #104, executing the ruling on #101.

Caesar's prompt-composition surface is its own invention with nothing upstream governing it — Wayfinder governs the map and the tickets, and Caesar overrode its `/research` subagent in favour of headless dispatch. So the map body inherits Pocock's rigour and the prompts inherit none of it.

#101 audited the two prompts dispatched in that session (#99, #100) and named four defects. Each is closed by a named part of the new file, and each is traceable to the lever in `writing-for-agents` that motivates it:

| Defect (#101) | Closed by | Lever |
|---|---|---|
| 1. No steps — flat prose, ordering left to inference | Part 3, `## Steps` numbered in execution order | Information hierarchy: in-file steps are the primary tier |
| 2. The completion criterion was the one element made fetchable | Part 4 — the prompt **stands alone**; a centurion that never runs `gh issue view` still knows when to stop | Progressive disclosure applied the right way round; completion criteria checkable and exhaustive |
| 3. Constraints restated while also pointing at the ticket that carries them | Part 5 — state each once; and the `## The frame` section, which lists what the heredoc already gives every centurion | Single source of truth |
| 4. Negation | `## Prompt the positive`, with three rewrites taken from the audited prompts, and the one legitimate guardrail (`bypassPermissions`) paired with its positive target | Positive phrasing; prohibitions only where unphrasable positively |

Per #101 the skill is applied **once**, here — no standing instruction to load `writing-for-agents` per session. The accepted cost is stated in that ruling: if the skill gains a lever later, this file does not inherit it until someone re-runs the derivation.

The file is written using the levers it documents, which is the ticket's own constraint: co-located rules (each rule sits with the part it governs, rather than in a second rules list), leading words reused rather than coined (*frame*, *cache*, *stands alone*), and the merge-gate five referenced by name rather than copied — `SKILL.md` remains their single source of truth.

## Proof it ran

Not dogfooded through a live dispatch — this is documentation, and dogfooding it means Caesar composing the next real prompt to it. What was verified:

- `git diff --stat` against `main`: `skill/SKILL.md | 3 +++`, plus the new file. Nothing else in the tree.
- The `SKILL.md` hunk sits entirely inside `## Dispatching a centurion`, above `### The skill block`, so it does not collide with `ticket-102-skill-block-table` rewriting the table in the same file.
- The relative link target `references/prompt-shape.md` resolves from `skill/SKILL.md`.
- Sources read in full before writing: `mattpocock-skills:writing-for-agents` including `SKILL-MECHANICS.md`; the #101 resolution comment; the guardrail heredoc at `skill/scripts/spawn-ticket-agent.ps1:102-126`; and the three worked prompts (`ticket-99-*`, `ticket-100-*`, `ticket-102-*.prompt.txt`).
- The `ticket-102` prompt was treated as a draft of the target rather than as evidence. Two places it falls short are fixed by the shape: it closes with *"Stop at the draft PR. Merging is Raj's call alone"*, which the frame already carries verbatim, and it has no *what only the disk knows* part.

## Riskiest hunks

1. `skill/SKILL.md:254-255` — the pointer. It is the only always-loaded cost here, and its wording decides whether a composing turn reaches the file at all. A weakly worded pointer to a must-have target is a variance bug, and this one is deliberately short; if a future Caesar composes a prompt without opening the file, sharpen the wording before inlining anything.
2. `skill/references/prompt-shape.md:54-57` — *"Where the deliverable is a PR, name the five things the merge gate wants … the centurion cannot see `SKILL.md`."* This deliberately declines to copy the five items, so the file stays correct only while that list lives at `SKILL.md` *Build work and the merge gate*. Moving or renaming that section breaks the reference silently.

## Blast radius and revertability

Documentation only, and `skill/` is the live skill via the junction from `C:\Users\rajdh\.claude\skills\caesar` — so on merge this changes what a Caesar session reads, and nothing else. No script, no heredoc, no deny list, no tier rubric, no concurrency cap, no table row. The worst realistic failure is a dispatch prompt shaped worse than it would otherwise have been.

Fully revertable: one revert of a single commit removes the pointer and the file together, with no state anywhere else to unwind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
