### PR TITLE
fix(skill): apply re-derived skill-block table (#102)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -306,9 +306,11 @@ per-ticket judgment and the only part you write by hand — one line, no rationa
 
 | Ticket shape | Name in the prompt |
 |---|---|
-| design or interface work | `impeccable` (2.7 MB on disk, 14 KB to load — #73; directory size is not cost) |
-| review ticket | the code-review skills — `numen-stack-review`, `codex-review` |
-| web retrieval | Firecrawl |
+| design or interface work | `impeccable` |
+| review ticket — written code | `mattpocock-skills:code-review`, with the fixed point in the prompt |
+| review ticket — a plan, not code | `codex-review` (reviews plans, not code, despite the name — [#89](https://github.com/Dhillvn/caesar/issues/89)) |
+| review ticket on the Numen stack (Supabase / Next.js / TS) | also `numen-stack-review` |
+| web retrieval | Firecrawl — `ToolSearch` for its tools first, they arrive deferred |
 | research past ~5 sources | **nothing — read the sources directly** |
 
 **The NotebookLM expectation is retired, not forgotten.**


### PR DESCRIPTION
## What changed
`skill/SKILL.md`'s skill-block table (rule 3, "name only what the ticket needs") rewritten to match the verdicts in `docs/research/caesar-skill-block-roster.md` (branch `research/100-skill-block-roster`):

- `impeccable` row: stripped the stale `(2.7 MB on disk, 14 KB to load — #73)` cost aside — #73's finding already lives in rule 2's prose above the table, so the row was carrying rationale rule 3 forbids.
- `review ticket` row split into three: written code → `mattpocock-skills:code-review` (namespaced against Claude Code's own `/code-review`; note that its own process asks the user for a fixed point if none is given, so the prompt must carry one or a headless agent stalls), a plan not code → `codex-review`, Numen-stack code → also `numen-stack-review`, layered on top of the code-review row rather than replacing it.
- `web retrieval` row: added the `ToolSearch`-first caveat — MCP tools are deferred and calling one before `ToolSearch` fails with `InputValidationError`; both Firecrawl and the new `tavily-search` connect after session start.
- `research past ~5 sources` row: unchanged, still a suppression rather than a naming.

Six new plugin skills that arrived since the table was last written (`code-review`, `tdd`, `diagnosing-bugs`, `resolving-merge-conflicts`, `wizard`, plus five more already on the roster) were each ruled in/out against the three governing rules; only `code-review` earned a row. `writing-for-agents` is out of scope — ruled separately by #101.

Also checked: whether `SKILL.md`'s note on `/implement` (line 566, "ends by committing to the current branch, creating no branch and opening no PR") is still accurate. Read the live skill at `mattpocock-skills/skills/engineering/implement/SKILL.md` — step 15 is "Commit your work to the current branch," no branch/PR creation anywhere in it. Still accurate, left unchanged.

## Why
[#102](https://github.com/Dhillvn/Caesar/issues/102), applying the proposal from [#100](https://github.com/Dhillvn/Caesar/issues/100). [#99](https://github.com/Dhillvn/Caesar/issues/99) found no name fixes were needed, so this PR is table-only. The `codex-review` row's correction turns on [#89](https://github.com/Dhillvn/Caesar/issues/89), which found it reviews plans, not written code, despite the name — cited inline in the row per the ticket's instruction.

## Proof it ran
`git diff main -- skill/SKILL.md` — 5 insertions, 3 deletions, table rows only. Confirmed no other hunks: `git diff --stat main` shows exactly one file changed. Row-by-row diffed against §4 of the proposal doc; content matches verbatim except the codex-review citation, which the ticket explicitly asked to add beyond what §4's table shows.

## Riskiest hunks
- `skill/SKILL.md:309-315` (new table) — this table is read by every future Caesar centurion-dispatch prompt; a wrong skill name here silently misdirects agents rather than erroring.
- `skill/SKILL.md:311` — `mattpocock-skills:code-review` namespacing depends on that prefix actually resolving; #99 found prefixes are optional but this is the first row to use one, so it's the least-tested part of the change.

## Blast radius and revertability
Single file, single section (the table under rule 3). The three governing rules above it, the guardrail heredoc, deny list, tier rubric, and concurrency cap in `spawn-ticket-agent.ps1` are all untouched. A `ticket-104-*` branch is editing a different section (`## Dispatching a centurion`) of the same file in parallel — no overlap. Fully revertable with a single `git revert` of this commit; no runtime state, no migrations, no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
