### PR TITLE
docs(skill): expression-only writing-for-agents pass over SKILL.md (#103)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -122,11 +122,15 @@ nothing.**
 six facts × every open ticket in front of that is a tollbooth paid every session. The
 table stays pull-only — it is one word away, "status".
 
-In order, one line each: **only what needs Raj** — a flag, a PR awaiting the word, a dirty
-leftover, the empty-frontier question — and *the whole section absent when there is
-nothing*; **what you already fired**, as a receipt for actions taken before he could
-object; **what you are taking and why**, one sentence, so his override still works; then
-the first grill question. On a clean session that is about four lines.
+In order, one line each:
+
+1. **Only what needs Raj** — a flag, a PR awaiting the word, a dirty leftover, the
+   empty-frontier question — and *the whole section absent when there is nothing*.
+2. **What you already fired**, as a receipt for actions taken before he could object.
+3. **What you are taking and why**, one sentence, so his override still works.
+4. Then the first grill question.
+
+On a clean session that is about four lines.
 
 ### Grill-only starts differently
 
@@ -316,16 +320,18 @@ per-ticket judgment and the only part you write by hand — one line, no rationa
 | web retrieval | Firecrawl — `ToolSearch` for its tools first, they arrive deferred |
 | research past ~5 sources | **nothing — read the sources directly** |
 
-**The NotebookLM expectation is retired, not forgotten.**
-[#74](https://github.com/Dhillvn/caesar/blob/main/docs/research/notebooklm-headless.md) measured it from inside a real centurion:
-query and ingest are both programmatically capable and neither is blocked by the deny
+**The NotebookLM expectation is retired, not forgotten.** Never write "have NotebookLM
+ingest the sources" into a prompt. If a ticket wants the notebook anyway, its preflight is
+`auth check --test` or the real query, and failure is a fallback to reading the sources
+directly, not a ticket-ending error.
+
+What paid for that rule:
+[#74](https://github.com/Dhillvn/caesar/blob/main/docs/research/notebooklm-headless.md) measured it from inside a real centurion.
+Query and ingest are both programmatically capable and neither is blocked by the deny
 list, but both ride browser cookies Google expires server-side (~10 days observed),
 renewable only by a human signing into a Chromium window — `auth refresh` cannot do it
 headless. Worse, `notebooklm auth check` reports *"Authentication is valid"* on a dead
-session, so a centurion believes it has access and fails downstream. Never write "have
-NotebookLM ingest the sources" into a prompt. If a ticket wants the notebook anyway, its
-preflight is `auth check --test` or the real query, and failure is a fallback to reading
-the sources directly, not a ticket-ending error.
+session, so a centurion believes it has access and fails downstream.
 
 ### The dispatch rubric — which tier
 
@@ -333,13 +339,6 @@ Every dispatch picks a **tier**, passed as `-Tier` to `spawn-ticket-agent.ps1`. 
 governs **dispatched agents only** — `wayfinder:research` tickets and AFK `wayfinder:task`
 tickets. Grilling and prototype tickets are HITL, worked by you and Raj in session, and
 never reach it.
-
-Why a rubric at all, and why this one: you always run on Opus. You read the map, pick the
-ticket and write the spec — so the *planning* half of the classic Opus-plans /
-Sonnet-executes split is already done, on Opus, before any centurion starts. The centurion
-is the executor. The discriminator is therefore not ticket *type* (which predicts nothing)
-and not a difficulty rating (unfalsifiable), but **whether the thinking has already
-happened**.
 
 Tiers are **named pairs**, not a model dial crossed with an effort dial. Independent dials
 would be twelve combinations and an argument at every dispatch.
@@ -362,6 +361,13 @@ wrong Execute call costs a wasted run plus a re-fire.
 If you cannot write both, it is Heavy. This is deliberately a test you can fail, because
 you both write the spec and pick the tier, and the cheap answer is always the one that
 looks like less work.
+
+Why a rubric at all, and why this one: you always run on Opus. You read the map, pick the
+ticket and write the spec — so the *planning* half of the classic Opus-plans /
+Sonnet-executes split is already done, on Opus, before any centurion starts. The centurion
+is the executor. The discriminator is therefore not ticket *type* (which predicts nothing)
+and not a difficulty rating (unfalsifiable), but **whether the thinking has already
+happened**.
 
 **Effort stays `medium` in two tiers of three.** Effort is the larger cost lever — an ~8x
 output-token span low→max against Opus's 1.67x over Sonnet — and it acts on all response
@@ -400,12 +406,6 @@ Note the pattern: **every Execute ticket sits downstream of a resolved decision.
 
 ### The watcher — how a landing reaches you
 
-`spawn-ticket-agent.ps1` detaches and returns immediately, so a finished centurion reaches
-nothing on its own: no `SubagentStop`, no background-task completion, no entry in `claude
-agents`. Without a watcher your only wake is Raj typing, and nothing obliges you to check
-on that turn — which is how a landed scout sits unreported until he asks. **He should never
-have to ask.**
-
 **Arm it once per session, at your first dispatch**, and leave it up:
 
 ```
@@ -426,6 +426,12 @@ else is wrong.
 One watcher covers every centurion on the machine, however many maps dispatched them — do
 not arm one per ticket. It backfills silently on start, so re-arming after a crash replays
 nothing and cannot double-append a gist to the map.
+
+What the watcher is for: `spawn-ticket-agent.ps1` detaches and returns immediately, so a
+finished centurion reaches nothing on its own: no `SubagentStop`, no background-task
+completion, no entry in `claude agents`. Without a watcher your only wake is Raj typing,
+and nothing obliges you to check on that turn — which is how a landed scout sits unreported
+until he asks. **He should never have to ask.**
 
 Six events, and **it returns no verdict** — same as `inspect-run.ps1`:
 
@@ -779,8 +785,10 @@ report state in chat, and act on his sentence.
 
 General non-Wayfinder work supervision.
 
+**Away-mode** — deciding and acting alone while Raj is gone. You wake, you report, you
+wait.
+
 Landing notifications were listed here — *"assume Raj is at the keyboard"* — until the
 assumption was tested and found wrong twice over: he is often away, and being present
 never woke you either, because nothing reached you on a landing at all. *The watcher*
-above replaces the whole item. What is still genuinely out of scope is **away-mode**:
-deciding and acting alone while he is gone. You wake, you report, you wait.
+above replaces the whole item.


### PR DESCRIPTION
## What changed

An expression-only `writing-for-agents` pass over `skill/SKILL.md`. Five hunks, no rule
touched:

1. **`### What the first turn says`** — the four-part run-on sentence describing the first
   turn became a numbered list. Same four items, same order, same qualifiers.
2. **NotebookLM block** — the operative rule ("never write *have NotebookLM ingest the
   sources* into a prompt", plus the preflight and the fallback) now leads; the #74 evidence
   that paid for it follows under *What paid for that rule*. Steps before reference.
3. **`### The dispatch rubric`** — the *why a rubric at all* derivation paragraph moved down
   to sit with the other rationale (beside the effort paragraph), so the decision material
   (named pairs → tier table → default → Execute gate) is reached first.
4. **`### The watcher`** — the arming instruction and the `Monitor(...)` block now open the
   section; the *why it exists* paragraph moved below the arming material as *What the
   watcher is for*.
5. **`## Out of scope for v1`** — the live scope item (**away-mode**) is now stated
   directly under the heading; the retired landing-notifications history follows it.

No script under `skill/scripts/` was touched: `writing-for-agents` gave no specific,
statable reason to, so `SKILL.md` alone is the deliverable, per the ticket.

Frozen content is byte-identical: the flag set, the deny list, the tier table under
*The dispatch rubric*, the concurrency cap, every issue link, every script name, every
parameter name, every literal path. Every section that existed still exists.

## Why

https://github.com/Dhillvn/Caesar/issues/103 — the skill is the document a Caesar session
acts on, and `writing-for-agents` is the method for that class of document. The levers
applied here are **information hierarchy** (steps before the reference that justifies them)
and **structure over prose** (a sequence written as a numbered list rather than left to
inference). A rewrite that would need a meaning change was not made; it is a Proposal below.

## Proof it ran

```
 skill/SKILL.md | 62 +++++++++++++++++++++++++++++++++-------------------------
 1 file changed, 35 insertions(+), 27 deletions(-)
```

Two mechanical checks, both run:

- **Word-multiset diff** of pre- vs post-change file (`tr` → `sort` → `uniq -c` → `diff`).
  Every delta is accounted for by the five hunks: list numbering and its capitalisation
  (`**only`→`**Only`, `then`→`Then`, `;`→`.`), the two added connector labels (*What paid
  for that rule:*, *What the watcher is for:*), `query`→`Query` at a new sentence start, and
  the out-of-scope restatement (`What is still genuinely out of scope is **away-mode**:
  … while he is gone` → `**Away-mode** — … while Raj is gone`, the scope framing now carried
  by the section heading it sits under). Nothing else was added or lost.
- **Survival re-check**: 212 inventory rows, carried by 211 distinct text anchors (row 84
  shares row 83's anchor line, row 100 shares row 99's), located by `grep -noF -f` in both
  the pre-change and the post-change file. **212/212 survive.** Every row below carries a
  tick and its post-change line number.

## The 1–2 riskiest hunks

- `skill/SKILL.md:364` — the *why a rubric at all* paragraph moved below the Execute gate.
  Nothing in it is a rule, but a reader who wants the derivation before the table now meets
  the table first. Deliberate: the table is what a dispatch needs.
- `skill/SKILL.md:429` — the watcher's rationale moved below the arming material, so
  *The watcher* now opens on an instruction rather than on the problem it solves. The
  `WATCHER-BAD-REPOPATH` caveat stays adjacent to the `Monitor(...)` block it annotates.

## Blast radius and revertability

One file, documentation only. No script, no flag, no parameter, no behaviour under test.
Fully revertable with `git revert` of the single commit — nothing depends on it and nothing
was generated from it. The repo copy is mirrored into `C:\Users\rajdh\.claude\skills\caesar\`
by a separate manual step, which this branch does not perform and must not be assumed done.

## Survival table

212 rows, built from the pre-change file top to bottom before any edit, re-checked against
the post-change file.

| # | Rule / constraint / threshold | pre | post | ✓ |
|---|---|---|---|---|
| 1 | Skill description and its trigger set | 3 | 3 | ✓ |
| 2 | Caesar drives Wayfinder maps, nothing else | 8 | 8 | ✓ |
| 3 | **Centurion** = spawned agent, **scout** = research ticket | 14 | 14 | ✓ |
| 4 | Resolve Wayfinder **by name, never by path** | 18 | 18 | ✓ |
| 5 | Wayfinder sets `disable-model-invocation: true` | 18 | 18 | ✓ |
| 6 | `claude plugin list --json` resolution one-liner | 22 | 22 | ✓ |
| 7 | `installPath` is the version the harness uses | 27 | 27 | ✓ |
| 8 | Never a literal Wayfinder path, never glob the plugin cache | 28 | 28 | ✓ |
| 9 | Command returns nothing → say Wayfinder is not installed | 31 | 31 | ✓ |
| 10 | Caesar carries the tracker ops; target repos need no tracker doc | 34 | 34 | ✓ |
| 11 | Infer `owner/repo` from the map URL | 39 | 39 | ✓ |
| 12 | Primary dispatches and owns the global cap; assume primary | 42 | 42 | ✓ |
| 13 | Grill-only: HITL tickets only, spawns nothing | 44 | 44 | ✓ |
| 14 | Four HITL tickets takeable at once | 46 | 46 | ✓ |
| 15 | Only one primary at a time | 49 | 49 | ✓ |
| 16 | Loose idea + no URL → chart a new map first | 51 | 51 | ✓ |
| 17 | No `resume` variant; no state file; cold start by construction | 56 | 56 | ✓ |
| 18 | **Four reads, in this order, then stop** | 61 | 61 | ✓ |
| 19 | Read 1 — `gh issue view <n> --repo <owner/repo> --json body` | 63 | 63 | ✓ |
| 20 | Map body carries the per-map config overrides | 65 | 65 | ✓ |
| 21 | Read 2 — `scripts/frontier.ps1 -MapUrl <url>` | 66 | 66 | ✓ |
| 22 | Read 3 — `git worktree list`, unconditionally | 67 | 67 | ✓ |
| 23 | Live `ticket-N-*` → arm the watcher before anything else | 69 | 69 | ✓ |
| 24 | Read 4 — `gh pr list` | 71 | 71 | ✓ |
| 25 | **No ticket bodies** until a ticket is picked (19+ context killer) | 74 | 74 | ✓ |
| 26 | Reads 2 and 4 portable; read 3 and run logs machine-bound | 77 | 77 | ✓ |
| 27 | A grill session never creates a worktree | 81 | 81 | ✓ |
| 28 | Claimed HITL — never touch it, say nothing | 85 | 85 | ✓ |
| 29 | One escape: empty frontier + claimed tickets → name them and ask | 88 | 88 | ✓ |
| 30 | No timeout, no staleness heuristic | 90 | 90 | ✓ |
| 31 | Claimed AFK, nothing on disk → check the GitHub artifact | 93 | 93 | ✓ |
| 32 | Comment but open → bookkeeping half-done, finish it yourself | 95 | 95 | ✓ |
| 33 | Branch/PR but no comment → work half-done, flag it | 96 | 96 | ✓ |
| 34 | Nothing at all → re-fire under the retry ceiling | 96 | 96 | ✓ |
| 35 | Attempt count is a ticket comment — **no new machinery** | 98 | 98 | ✓ |
| 36 | Load-bearing assumption: one machine, one checkout per repo | 100 | 100 | ✓ |
| 37 | Worktrees named `ticket-<number>-<random>` by the spawn script | 108 | 108 | ✓ |
| 38 | Delete only what you can prove you created and that holds nothing | 109 | 109 | ✓ |
| 39 | Closed + teardown succeeds → delete silently | 114 | 114 | ✓ |
| 40 | Closed + teardown refuses → report once, resolution attached | 115 | 115 | ✓ |
| 41 | Ticket open → not an orphan, live-centurion case | 116 | 116 | ✓ |
| 42 | Not `ticket-N-*` → never delete; report once and ask | 117 | 117 | ✓ |
| 43 | First turn ends with the pick, not the table | 121 | 121 | ✓ |
| 44 | Table is pull-only, one word away — "status" | 123 | 123 | ✓ |
| 45 | First-turn order, one line each (4 items) | 125 | 125 | ✓ |
| 46 | About four lines on a clean session | 129 | 133 | ✓ |
| 47 | Grill-only reads two things: map body and `frontier.ps1` | 133 | 137 | ✓ |
| 48 | Grill-only: no `git worktree list`, no teardown | 133 | 137 | ✓ |
| 49 | Grill-only surfaces no PRs — the primary is the sole surfacer | 136 | 140 | ✓ |
| 50 | Grill-only + AFK-only frontier → say so exactly, and stop | 140 | 144 | ✓ |
| 51 | Why startup is prose, not a script | 145 | 149 | ✓ |
| 52 | A `startup.ps1` earns its place only on dogfooding evidence | 148 | 152 | ✓ |
| 53 | The repo constraint, checked first | 156 | 160 | ✓ |
| 54 | Offer `gh repo create`, private, as the map's first AFK task | 159 | 163 | ✓ |
| 55 | Never host a map in Drive markdown | 160 | 164 | ✓ |
| 56 | Chart step 1 — name the destination | 164 | 168 | ✓ |
| 57 | Chart step 2 — grill again, breadth-first | 167 | 171 | ✓ |
| 58 | No fog surfaces → nothing to chart; say so and ask | 168 | 172 | ✓ |
| 59 | Chart step 3 — create the map, labelled `wayfinder:map` | 171 | 175 | ✓ |
| 60 | Chart step 4 — tickets labelled `wayfinder:<type>`, as sub-issues | 173 | 177 | ✓ |
| 61 | Chart step 5 — wire blocking in a second pass | 175 | 179 | ✓ |
| 62 | The four `gh` charting commands | 179 | 183 | ✓ |
| 63 | Both relationship endpoints take the numeric database id | 186 | 190 | ✓ |
| 64 | Bodies travel through a file | 187 | 191 | ✓ |
| 65 | Labels must already exist; `gh label create` first | 190 | 194 | ✓ |
| 66 | No new script for charting | 194 | 198 | ✓ |
| 67 | Fog, not pre-sliced tickets | 197 | 201 | ✓ |
| 68 | Declare the shape before you drive; a **partial** is declared up front | 202 | 206 | ✓ |
| 69 | Then drive — do not stop at the handover | 207 | 211 | ✓ |
| 70 | Why this is not `/wayfinder` in charting mode | 212 | 216 | ✓ |
| 71 | Research goes out through `spawn-ticket-agent.ps1`, never subagents | 216 | 220 | ✓ |
| 72 | Charting flows into driving | 217 | 221 | ✓ |
| 73 | Loop 1 — sweep with `scripts/frontier.ps1` | 225 | 229 | ✓ |
| 74 | Loop 2 — fire AFK work first, up to the cap, queue the rest | 227 | 231 | ✓ |
| 75 | Loop 3 — one HITL ticket; you are the channel | 230 | 234 | ✓ |
| 76 | Loop 4 — harvest: verify, append the gist, tear down | 233 | 237 | ✓ |
| 77 | Loop 5 — repeat until the frontier is empty | 236 | 240 | ✓ |
| 78 | Never more than one HITL ticket per session; research exempt | 238 | 242 | ✓ |
| 79 | Name the map and ticket you are picking, and why | 242 | 246 | ✓ |
| 80 | Claim before you work — assign to Raj's login | 245 | 249 | ✓ |
| 81 | One headless `claude -p` per ticket, each in its own worktree | 250 | 254 | ✓ |
| 82 | Script carries the flag set and deny list; never hand-compose | 251 | 255 | ✓ |
| 83 | Pointer to `references/prompt-shape.md` | 255 | 259 | ✓ |
| 84 | Pointer text: ordered shape + what the guardrail frame carries | 255 | 259 | ✓ |
| 85 | Centurion posts its own comment, closes its own ticket, prints `GIST:` | 257 | 261 | ✓ |
| 86 | Never treat an exit code as evidence of work done | 261 | 265 | ✓ |
| 87 | Nested `--permission-mode bypassPermissions` is auto-denied | 265 | 269 | ✓ |
| 88 | **Concurrency: 4 centurions, globally, across all maps** | 269 | 273 | ✓ |
| 89 | `-BudgetUsd` default 5.0; both overridable per-map in **Notes** | 271 | 275 | ✓ |
| 90 | Centurion inherits both `CLAUDE.md`s, skills, hooks (#72) | 276 | 280 | ✓ |
| 91 | Skill block is an override layer, not a re-listing | 279 | 283 | ✓ |
| 92 | Rule 1 — never re-list what is inherited | 282 | 286 | ✓ |
| 93 | Rule 2 — never retype an exclusion | 288 | 292 | ✓ |
| 94 | `claude-api` is the one banned skill — **ban nothing else** | 291 | 295 | ✓ |
| 95 | #73: 119 `SKILL.md` files, 0.94×, largest ordinary skill 45 KB ≈ 6% of the $5.00 cap | 292 | 296 | ✓ |
| 96 | `claude-api` injects 898 KB / ~345K tokens / 147% of cap | 294 | 298 | ✓ |
| 97 | The old blanket ban on large reference skills is retired | 298 | 302 | ✓ |
| 98 | New-skill test is structural; threshold **100 KB injected** | 301 | 305 | ✓ |
| 99 | Re-run `scripts/skill_cost.py` after an upgrade; 799 KB → 898 KB | 304 | 308 | ✓ |
| 100 | Only Raj adds to the ban; a centurion reads banned files off disk | 304 | 308 | ✓ |
| 101 | Rule 3 — name only what the ticket needs, one line, no rationale | 307 | 311 | ✓ |
| 102 | The skill-block table (6 rows, #106/#107 content, unchanged) | 312 | 316 | ✓ |
| 103 | The NotebookLM expectation is retired, not forgotten | 319 | 323 | ✓ |
| 104 | Never write "have NotebookLM ingest the sources" into a prompt | 326 | 323 | ✓ |
| 105 | Preflight is `auth check --test`; failure falls back, not fatal | 327 | 325 | ✓ |
| 106 | Tier passed as `-Tier` to `spawn-ticket-agent.ps1` | 332 | 338 | ✓ |
| 107 | Rubric governs dispatched agents only; HITL never reaches it | 333 | 339 | ✓ |
| 108 | Discriminator is whether the thinking has already happened | 341 | 369 | ✓ |
| 109 | Tiers are named pairs, not two dials (twelve combinations) | 344 | 343 | ✓ |
| 110 | Tier table — Heavy / Execute / Tail, model + effort (frozen) | 349 | 348 | ✓ |
| 111 | Tail is never a dispatch choice — retry-only or per-map override | 351 | 350 | ✓ |
| 112 | Default when in doubt: Heavy | 353 | 352 | ✓ |
| 113 | The Execute gate — objective, both conditions stated | 356 | 355 | ✓ |
| 114 | If you cannot write both, it is Heavy | 362 | 361 | ✓ |
| 115 | Effort stays `medium` in two tiers of three; ~8x span, 1.67x | 366 | 372 | ✓ |
| 116 | #64: Sonnet-low 8.8–15.4% cheaper; Raj held `medium` 2026-08-05 | 373 | 379 | ✓ |
| 117 | Budget cap flat **$5.00** for every tier | 380 | 386 | ✓ |
| 118 | Tier, model, effort and cap recorded on every run record | 383 | 389 | ✓ |
| 119 | Worked-examples table (#50, #55, #58, #60, #56, #52, #53) | 391 | 397 | ✓ |
| 120 | Every Execute ticket sits downstream of a resolved decision | 399 | 405 | ✓ |
| 121 | Spawn detaches: no `SubagentStop`, no task completion, no `claude agents` | 404 | 431 | ✓ |
| 122 | He should never have to ask | 406 | 434 | ✓ |
| 123 | Arm the watcher once per session, at the first dispatch | 409 | 409 | ✓ |
| 124 | The `Monitor(...)` / `watch-runs.ps1` invocation | 413 | 413 | ✓ |
| 125 | Both Windows paths quoted — load-bearing | 417 | 417 | ✓ |
| 126 | `WATCHER-BAD-REPOPATH` → re-arm with the path quoted | 423 | 423 | ✓ |
| 127 | One watcher covers every centurion; never one per ticket | 426 | 426 | ✓ |
| 128 | Backfills silently on start; re-arming cannot double-append | 427 | 427 | ✓ |
| 129 | Six events, and it returns no verdict | 430 | 436 | ✓ |
| 130 | Event table — `LANDED`, `LANDED-NO-GIST`, `ERRORED`, `DIED-AT-SPAWN`, `QUIET`, `NO-TRANSCRIPT` | 434 | 440 | ✓ |
| 131 | `DIED-AT-SPAWN` once vs `NO-TRANSCRIPT` every `-RecheckMinutes` | 441 | 447 | ✓ |
| 132 | `LANDED` ≠ accept the gist; `QUIET` ≠ kill it | 446 | 452 | ✓ |
| 133 | Never hand-poll the run directory | 449 | 455 | ✓ |
| 134 | Mid-grill default: one gist line, then back to the question | 454 | 460 | ✓ |
| 135 | Stop the grill only on contradiction, drift, or error | 458 | 464 | ✓ |
| 136 | You are the smell test, not Raj | 459 | 465 | ✓ |
| 137 | Retry a bad roll, flag a wall — **one retry maximum, ever** | 465 | 471 | ✓ |
| 138 | `inspect-run.ps1`, `-ResultFile` from a later session; no verdict | 471 | 477 | ✓ |
| 139 | Failure table — 7 rows, transient → coherently wrong | 477 | 483 | ✓ |
| 140 | Wrong never retries — new information may change Raj's mind | 485 | 491 | ✓ |
| 141 | One licensed escalation: complete-but-inadequate Execute → Heavy once | 490 | 496 | ✓ |
| 142 | Escalation does not raise the one-retry maximum | 496 | 502 | ✓ |
| 143 | Every other class retries at the same tier; budget death never escalates; Heavy → Tail never automatic | 499 | 505 | ✓ |
| 144 | Non-empty `permission_denials` is not a failure signal | 505 | 511 | ✓ |
| 145 | At 30 minutes you look, you do not kill; re-arrives every 15 | 510 | 516 | ✓ |
| 146 | On `QUIET` read the heartbeat; not moving → kill by PID, triage | 515 | 521 | ✓ |
| 147 | `-QuietMinutes` / `-RecheckMinutes`, overridable per-map | 518 | 524 | ✓ |
| 148 | A wedge is not automatically a flag | 521 | 527 | ✓ |
| 149 | A death is not on the clock; reported exactly once | 524 | 530 | ✓ |
| 150 | Fresh spawn, fresh worktree; never `--resume` | 533 | 539 | ✓ |
| 151 | Attempt count is a ticket comment; `.claude/caesar-runs/` is scratch | 536 | 542 | ✓ |
| 152 | Flag = `caesar:needs-raj` + stays assigned + comment | 542 | 548 | ✓ |
| 153 | `frontier.ps1` reports `flagged`; `status.ps1` renders **Needs you** | 545 | 551 | ✓ |
| 154 | Never leave a failed ticket open and unassigned | 547 | 553 | ✓ |
| 155 | Label marks any stopped AFK ticket; HITL never carries it | 552 | 558 | ✓ |
| 156 | Retries fire silently; flags queue and surface at a break | 554 | 560 | ✓ |
| 157 | `scripts/status.ps1 -MapUrl <url> [<url> ...]` on any status ask | 560 | 566 | ✓ |
| 158 | Six facts per open ticket; rows sort by what needs him | 564 | 570 | ✓ |
| 159 | `caesar:hitl` stamped at the moment the task needs his hands | 567 | 573 | ✓ |
| 160 | `main` changes only on Raj's explicit word | 574 | 580 | ✓ |
| 161 | May press merge, never on inferred consent; name the PR | 576 | 582 | ✓ |
| 162 | `/implement` commits to the current branch, opens no PR | 580 | 586 | ✓ |
| 163 | Five things every PR carries before asking for the word | 585 | 591 | ✓ |
| 164 | Evidence "not run" → escalates to a line-by-line read | 592 | 598 | ✓ |
| 165 | Ready PRs queue and land at a break in the grill | 593 | 599 | ✓ |
| 166 | Post-merge revert on the spot, then re-ticket the redo | 596 | 602 | ✓ |
| 167 | Raj initiates a veto; Caesar never self-vetoes | 602 | 608 | ✓ |
| 168 | The map must read true — `Decisions so far` is the bootstrap | 606 | 612 | ✓ |
| 169 | Rewrite in place: not struck through, not appended, never deleted | 609 | 615 | ✓ |
| 170 | Unwinding = reopen, comment, stamp `caesar:needs-raj` | 613 | 619 | ✓ |
| 171 | A veto that changes the question is ordinary charting | 615 | 621 | ✓ |
| 172 | Sweep one hop, report, reopen nothing (`veto-sweep.ps1`) | 618 | 624 | ✓ |
| 173 | Do not reach for `gh search issues` — #30's 12-of-~20 noise | 623 | 629 | ✓ |
| 174 | Centurions in the field are dependants; drain or kill is Raj's call | 627 | 633 | ✓ |
| 175 | Shipped vetoed decision → the merge gate's revert owns the code half | 630 | 636 | ✓ |
| 176 | Every centurion gets its own worktree, always | 635 | 641 | ✓ |
| 177 | Centurion renames onto a legible branch | 639 | 645 | ✓ |
| 178 | `remove-worktree.ps1` is fail-closed | 640 | 646 | ✓ |
| 179 | Report a leftover once, with the resolution attached | 643 | 649 | ✓ |
| 180 | A map is yours only while it carries `caesar:driving` | 649 | 655 | ✓ |
| 181 | Discovery: `gh search issues --owner Dhillvn --label ...` | 653 | 659 | ✓ |
| 182 | `--owner` is mandatory | 656 | 662 | ✓ |
| 183 | No state file — GitHub and `git worktree list` are the truth | 658 | 664 | ✓ |
| 184 | Withdrawing is drain, never kill | 662 | 668 | ✓ |
| 185 | Caesar is the sole writer to the map body | 667 | 673 | ✓ |
| 186 | Last-write-wins; every map write is **read-verify-retry** | 673 | 679 | ✓ |
| 187 | Never compose it by hand — `map-body.ps1` is the only way | 676 | 682 | ✓ |
| 188 | The two `map-body.ps1` calls; edit the file between them | 680 | 686 | ✓ |
| 189 | The body must never become a PowerShell value — 25 KB lost in #36 | 687 | 693 | ✓ |
| 190 | `.claude/caesar-runs/map-backups/` is the only undo | 688 | 694 | ✓ |
| 191 | The script verifies structure, not phrasing; byte floor; pre-write | 691 | 697 | ✓ |
| 192 | `Written=$false` vs `WRITTEN BUT DAMAGED` → run `Restore` at once | 697 | 703 | ✓ |
| 193 | `-AllowShrink` is a claim you are making — say so in chat | 699 | 705 | ✓ |
| 194 | Military verbs on Wayfinder's own nouns; import nothing | 706 | 712 | ✓ |
| 195 | **No Latin, ever** — only language Raj reads at full speed | 712 | 718 | ✓ |
| 196 | Ranks: `map`/`ticket`/`frontier`/`fog` Wayfinder's; centurion/scout Caesar's | 719 | 725 | ✓ |
| 197 | *Legate* rejected on recognisability | 722 | 728 | ✓ |
| 198 | Script names, parameters and variables keep `agent`; spawn script frozen | 724 | 730 | ✓ |
| 199 | Address: Raj is **Consul** at three moments; the authority is **Rome** | 727 | 733 | ✓ |
| 200 | **Crossing the Rubicon** = merging to `main` | 731 | 737 | ✓ |
| 201 | Manner: state the action, no hedges; authority out of scope | 735 | 741 | ✓ |
| 202 | Bad news is plain — no flavour at all | 740 | 746 | ✓ |
| 203 | Voice on/off table (6 surfaces off, 1 on) | 749 | 755 | ✓ |
| 204 | Six surfaces off, one on — nothing durable changes | 755 | 761 | ✓ |
| 205 | Caveman override is not like-for-like; two parts | 761 | 767 | ✓ |
| 206 | In conversation, Caesar's register replaces caveman | 765 | 771 | ✓ |
| 207 | Outside conversation, durable artifacts are neutral prose | 768 | 774 | ✓ |
| 208 | Both parts hold only inside a `/caesar` session | 772 | 778 | ✓ |
| 209 | Solo operator learning GitHub — never make him drive the tracker | 775 | 781 | ✓ |
| 210 | Out of scope: general non-Wayfinder work supervision | 780 | 786 | ✓ |
| 211 | Out of scope: away-mode — you wake, you report, you wait | 786 | 788 | ✓ |
| 212 | Landing notifications retired; *The watcher* replaces the item | 782 | 791 | ✓ |

**212/212 rows survive.** No row failed, so no edit was reverted.

## Proposals — better expression that would need a meaning change, so not made

1. **Disclose the three long reference blocks.** *The dispatch rubric* (~70 lines), *When a
   centurion fails* (~70 lines) and *The watcher* (~50 lines) are in-file reference sitting
   above a steps document, and `writing-for-agents` would push them to
   `skill/references/` behind context pointers, the way #104 did for the prompt shape. Not
   done here because moving material out of the always-loaded file changes what a session
   holds in context — a behaviour change, not an expression change. Worth its own ticket,
   with the pointer wording as the real deliverable.

2. **Prompt the positive on the standing prohibitions.** *Never treat an exit code as
   evidence of work done* (`SKILL.md:265`), *Never hand-poll the run directory* (`:455`),
   *Never resolve more than one HITL ticket per session* (`:242`). Each is a negation, and
   `writing-for-agents` prefers the positive target. Each is also a hard guardrail written
   after a real failure, and the positive rephrasing drops the named prohibition, which is
   a meaning change. Left exactly as they stand.

3. **The "no new script" reasoning appears twice** — `SKILL.md:149` (*Why this is prose and
   not a script*) and `:198` (*No new script for any of this*, explicitly citing "the same
   reasoning that kept startup as prose"). This looks like duplication, and the ticket asks
   that apparent redundancy be named rather than cut: the second is a back-reference, not a
   restatement, and it keeps the charting section self-contained. Section left standing.

4. **Sprawl.** The file is 795 lines and every line is live. The clean split is by branch —
   charting versus driving — since a session takes one path or the other. That is a split
   decision, not a wording one, so it belongs to a ticket that can weigh the invocation cost.

5. **`skill/scripts/`.** Read for prose (comments, the guardrail heredoc). No specific
   `writing-for-agents` finding was statable that did not also change what a centurion is
   told, so no script was touched, per the ticket's own rule.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
