### PR TITLE
docs(skill): derive the pointer standard as a disclosed reference (#112)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -256,7 +256,9 @@ its own git worktree. The script carries the flag set and the deny list; do not 
 that command by hand.
 
 **Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
-already carries: [`references/prompt-shape.md`](references/prompt-shape.md).
+already carries. Read it before you write one; a prompt shaped from memory restates the frame
+and leaves the centurion with no bound of its own:
+[`references/prompt-shape.md`](references/prompt-shape.md).
 
 The centurion **posts its own resolution comment and closes its own ticket**, then prints a
 `GIST:` line. You read only the gist and append it to the map. This keeps your context
@@ -600,6 +602,10 @@ Ready PRs **queue and land at a break in the grill** — interrupting a grill to
 a merge is how a spot-check degrades into a rubber stamp.
 
 Post-merge, if Raj says revert: revert on the spot, then re-ticket the redo.
+
+**Pointers into `references/`** — the standard one meets before it ships: what it states, how
+its leading word is chosen, and how its strength scales with the cost of a miss. Read it
+before you write or reword one: [`references/pointer-standard.md`](references/pointer-standard.md).
 
 ## When Raj vetoes a closed decision
 

--- a/skill/references/pointer-standard.md
+++ b/skill/references/pointer-standard.md
@@ -124,12 +124,14 @@ if the link is never followed.
 wrong tier, expensive but visible and reversible.
 
 ```
-**Which tier a ticket takes** — the dispatch rubric: Execute, Heavy, HITL, and what each
-does to the concurrency cap. Read it before you dispatch and before you hand a ticket back:
+**Which tier a ticket takes** — the dispatch rubric: Heavy or Execute, the gate that
+separates them, and the one licensed escalation. Read it before you dispatch, and before you
+re-fire a run that failed:
 [`references/dispatch-rubric.md`](references/dispatch-rubric.md).
 ```
 
-Two branches, both real — dispatch and handback take different paths through the rubric.
+Two branches, both real — a first dispatch and a re-fire take different paths through the
+rubric.
 
 **Voice** — *naming*: the cost of a miss is a report in flat prose, which is cosmetic.
 

--- a/skill/references/pointer-standard.md
+++ b/skill/references/pointer-standard.md
@@ -1,0 +1,141 @@
+# The pointer standard
+
+A **context pointer** is the line left behind in `SKILL.md` when material moves out of it and
+into `references/`. It is the only thing deciding whether a session reaches that material:
+the target is already written, the wording is what fires or does not fire. So a block moved
+behind a weak line is not disclosed, it is deleted with extra steps.
+
+Derived once from `writing-for-agents`
+([#112](https://github.com/Dhillvn/Caesar/issues/112)) so the disclosures on
+[#109](https://github.com/Dhillvn/Caesar/issues/109) are written to one rule rather than
+improvised six times. Applying it needs nothing but this file.
+
+## 1. What a pointer states
+
+Two things, and it is not finished until it carries both.
+
+**The material** — what is behind the link, in the terms a session would use to ask for it.
+Not the file's subject in the abstract: the specific contents it will be reached *for*. *"the
+failure table"* is the material. *"notes on failures"* is not.
+
+**The branches that trigger reaching it** — a **branch** is a distinct case the material
+handles, so different runs take different paths through it. A branch is written as the
+concrete moment in a run: *before you retry*, *before you hand back*, *when the ticket is
+HITL*. A pointer that names material but no branch tells a session what exists and never
+tells it when to look, which is the common way a disclosed block goes cold.
+
+The form the two make, and the one this file's own pointer takes:
+
+```
+**<leading word> — <the material>. <the branch, or branches>:
+[`references/<file>.md`](references/<file>.md).
+```
+
+The link carries the path. Prose that also announces where the file lives is the path
+written twice.
+
+## 2. Choosing the leading word
+
+A **leading word** is a compact concept the model already holds from pretraining, which the
+session thinks with while it runs. In a pointer it does the *invocation* work: when the same
+word lives in the prompt, in this skill, and in the scripts, the session links that shared
+language to the material and reaches it more reliably.
+
+Caesar already runs a set: `frontier`, `fog`, `centurion`, `scout`, `map`, `ticket`, and
+*crossing the Rubicon*. These are the pointers' first assets, and they are spent by one rule:
+
+**Lead with the word the session is already holding when the branch fires.** A run about to
+kill a stalled process is holding `centurion`; a run picking what to work next is holding
+`frontier`. That word, first, is the pointer's strongest hook — put it in the opening token
+rather than behind framing like *"for more on…"*.
+
+Three consequences:
+
+- **One running word, one target.** If two pointers both open on `centurion`, neither fires
+  cleanly. Qualify with the running word plus the act — *dispatching a centurion*, *a
+  centurion that fails* — so the pair stays distinguishable.
+- **Where no running word fits, reach for an existing one, not a new one.** *Retry*,
+  *dispatch*, *merge*, *worktree* all carry priors. A coined word recruits none: you pay in
+  definition tokens what a pretrained word gives free.
+- **The word must also be the body's word.** The pointer and the file it reaches share
+  vocabulary, or the session that follows the link finds a document that reads as a different
+  subject and drops it.
+
+## 3. Pruning a line that is loaded every turn
+
+The body behind a pointer costs only when reached. The pointer costs on every turn, whether
+or not it fires, so it earns harder pruning than the material it names.
+
+- **One trigger per branch.** Synonyms renaming a single branch are one branch written twice
+  — *before you retry, re-run, or try again* is one branch. Collapse them, keep only branches
+  that genuinely take different paths through the material.
+- **Cut identity the body already carries.** The file states its own subject in its first
+  line. A pointer that also says *this document explains…* or restates the file's title as
+  prose buys nothing.
+- **Front-load, then stop.** Leading word, material, branches, link. Everything before the
+  leading word is load with no trigger in it.
+- **The deletion test.** Take any word out. If no branch stops firing, it was never doing
+  triggering work — leave it out.
+
+## 4. How strength scales with the cost of a miss
+
+**Strength** is how much of the pointer's line is spent making the session actually go. It is
+set by one question: *what happens if this never fires and the session proceeds from memory?*
+The costs across this skill differ by an order of magnitude — a missed voice note is
+cosmetic, a missed line from the failure table means a centurion is mishandled — so a single
+strength for every pointer is either waste or a live bug.
+
+Four rungs. Take the lowest one the cost allows.
+
+1. **Naming.** The session is fine without it; it just reads better with it. Material plus
+   one branch, no obligation. *Cosmetic cost — a voice note, a rationale, a piece of history.*
+2. **Firm.** Reaching it is stated as a step in the run: *read it before you compose one*.
+   Branches named explicitly rather than implied. *Cost is a wasted run or a rework.*
+3. **Hard.** Firm, plus the pointer carries the **one fact whose absence is dangerous** — a
+   stub inline in the pointer line itself, so a session that never follows the link still
+   does not act on a wrong assumption. Say what the miss costs, in the pointer. *Cost is
+   silent and unrecoverable: a mishandled centurion, a lost run, `main` touched.*
+4. **Inline.** The material does not move. Reserved for what every branch needs anyway —
+   disclosure only protects the top of the file when what it pushes down is genuinely
+   branch-local.
+
+Climb the ladder in that order, and only on evidence: sharpen the wording first, raise the
+strength second, keep it inline last. Reaching for rung 3 on everything spends the line
+budget that makes rung 3 legible where it is earned.
+
+## 5. Worked examples
+
+Three, written as they would land in `SKILL.md`, for material this map is likely to disclose.
+
+**A centurion that fails** — *hard*, because the miss is silent: a failure classed from
+memory retries a run that needed Raj, and the retry looks like progress.
+
+```
+**A centurion that fails** — the failure table: which failures retry, which stamp
+`caesar:needs-raj`, which are Raj's call and not yours. Read it before you retry, flag or
+kill; a failure classed from memory is the one that reads as progress:
+[`references/failure-modes.md`](references/failure-modes.md).
+```
+
+The stub is *which are Raj's call and not yours* — the fact a session must not guess at even
+if the link is never followed.
+
+**Which tier a ticket takes** — *firm*: the cost of a miss is a ticket dispatched at the
+wrong tier, expensive but visible and reversible.
+
+```
+**Which tier a ticket takes** — the dispatch rubric: Execute, Heavy, HITL, and what each
+does to the concurrency cap. Read it before you dispatch and before you hand a ticket back:
+[`references/dispatch-rubric.md`](references/dispatch-rubric.md).
+```
+
+Two branches, both real — dispatch and handback take different paths through the rubric.
+
+**Voice** — *naming*: the cost of a miss is a report in flat prose, which is cosmetic.
+
+```
+**Voice** — the ranks, the address, and the surfaces the flavour is off on:
+[`references/voice.md`](references/voice.md).
+```
+
+No obligation verb, no cost clause. Both would be spent on a line that changes no decision.


### PR DESCRIPTION
## What changed

- **Added `skill/references/pointer-standard.md`** — the standard a Caesar context pointer is written to, in five parts: (1) what a pointer states — the material plus the branches that trigger reaching it; (2) how its leading word is chosen from the vocabulary Caesar already runs (`frontier`, `fog`, `centurion`, `scout`, `map`, `ticket`, *crossing the Rubicon*), with the one-running-word-one-target rule; (3) the pruning rules for a line loaded every turn — one trigger per branch, synonyms collapsed, identity the body already carries cut, plus a deletion test; (4) a four-rung strength ladder (naming → firm → hard → inline) scaled to what a miss costs; (5) three worked pointers for material map #109 is likely to disclose — the failure table (*hard*), the dispatch rubric (*firm*), the voice section (*naming*).
- **`skill/SKILL.md`, pointer lines only** — one new pointer reaching the standard, added at the end of *Build work and the merge gate*; and the existing `prompt-shape.md` pointer rewritten (verdict below).

The standard is self-contained: a ticket that applies it does not need to load `writing-for-agents`.

## Why

https://github.com/Dhillvn/Caesar/issues/112.

Map https://github.com/Dhillvn/Caesar/issues/109 moves several blocks out of `skill/SKILL.md` into `skill/references/`. Those blocks are in context on every turn today. Once moved, the pointer's wording is the only thing deciding whether a session reaches them — so the pointers, not the moves, are the restructure's real deliverable, and they are derived once here instead of improvised six times later. The costs of a miss differ by an order of magnitude across this skill (a missed voice note is cosmetic; a missed line from the failure table means a centurion is mishandled), which is why the standard carries a strength ladder rather than one uniform pointer shape.

## Proof it ran

`git diff main --stat`:

```
 skill/SKILL.md                       |   8 +-
 skill/references/pointer-standard.md | 141 +++++++++++++++++++++++++++++++++++
 2 files changed, 148 insertions(+), 1 deletion(-)
```

`skill/SKILL.md` changes by the two pointer lines only — no section moved, no existing rule reworded. The frozen content (flag set, deny list, tier table, concurrency cap, issue links, script names, parameter names, literal paths) is untouched.

### Verdict on the `prompt-shape.md` pointer: **rewritten**

It passed parts 1–3 of the standard cleanly — it names its material (the ordered shape, and what the guardrail frame already carries), it carries no synonym duplication, and it restates no identity the body already holds. It failed part 4. The cost of that pointer failing to fire is a centurion dispatched on a prompt shaped from memory: the frame restated as a second authority, and no completion bound in the prompt at all — a whole run burned, silently, because the dispatch still looks well-formed. That is a *firm* cost, and the line was written at *naming* strength: no branch stated as a step, no cost of a miss.

Before:

```
**Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
already carries: [`references/prompt-shape.md`](references/prompt-shape.md).
```

After:

```
**Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
already carries. Read it before you write one; a prompt shaped from memory restates the frame
and leaves the centurion with no bound of its own:
[`references/prompt-shape.md`](references/prompt-shape.md).
```

The leading phrase is unchanged — it already sits under `## Dispatching a centurion` and leads on running vocabulary. What is added is the branch as a step (*read it before you write one*) and the cost of the miss.

## Riskiest hunks

1. `skill/SKILL.md:606` — the new pointer's placement. It sits at the end of *Build work and the merge gate*, which is where editing this skill is governed, but #109 will be moving sections around this file; if that section is itself disclosed later, this pointer moves with it and needs re-siting rather than duplicating.
2. `skill/SKILL.md:258` — the rewritten `prompt-shape.md` pointer. Three lines instead of two, on a line that is loaded every turn. The added words are branch and cost, both of which do triggering work under part 3's deletion test, but this is the one place in the diff where always-loaded context grew.

## Blast radius and revertability

Documentation only — one new reference file plus two pointer lines. No script, no map, no ticket, no runtime behaviour changed. Fully revertable by reverting the single commit; nothing downstream depends on the new file yet. The standard's real exposure is forward: it is what #109's disclosures will be written to, so a wrong rule here propagates into six pointers later — which is the argument for reading part 4's ladder closely before merge.
