### PR TITLE
Branch harness: drive a Caesar session against fixture maps and report the references it reads (#111)

### DIFF
--- a/docs/harness-blind-spots.md
+++ b/docs/harness-blind-spots.md
@@ -1,0 +1,80 @@
+# What the branch harness cannot see
+
+`scripts/branch-harness.ps1` drives a real Caesar session against a disposable fixture map
+and reports which of the skill's reference files that session read. Every claim made on the
+skill-restructure map (#109) rests on that report, so every claim is bounded by this list.
+Read it before quoting a harness result as evidence.
+
+## 1. A read is not a use
+
+The transcript records that a file was opened. It records nothing about whether the session
+understood it, followed it, or acted on it. A pointer that fires and is then ignored is
+indistinguishable here from a pointer that fires and changes the answer. The harness can
+prove a pointer is *reachable*; it cannot prove it is *load-bearing*.
+
+## 2. Not reading is not proof of not knowing
+
+The session inherits SKILL.md in full at skill-load time. Anything already written in
+SKILL.md needs no read, so a branch that produces the right behaviour with an empty read
+list has told us nothing about whether a reference would have helped. This cuts the other
+way too: after a restructure, a *fall* in reads is ambiguous between "the pointer is dead"
+and "the session already had what it needed".
+
+## 3. One roll, not a distribution
+
+Each fixture is one session. Model behaviour is stochastic, and a pointer that fires four
+times in five reads as "fires" on one run and "does not fire" on another. Nothing here is
+run to significance, and the harness has no repeat mode. Treat a single missing read as a
+lead, not a finding.
+
+## 4. Dispatch is switched off
+
+The harness prompt tells the session that `spawn-ticket-agent.ps1` and nested `claude` calls
+will not run, and to compose and print the dispatch prompt instead of firing it. That keeps
+a fixture run from spending real money and littering real worktrees, and it is why the
+Drive-with-a-dispatch fixture is observable at all. But it means the harness observes the
+session **up to** the spawn and never past it. Anything a centurion would read, and anything
+SKILL.md says about harvesting a landing, is outside the frame.
+
+## 5. Fixture maps are small, and context pressure is the thing being restructured
+
+Every fixture map has two or three children. Real maps run to nineteen. The restructure this
+harness exists to check is largely about context cost, and the harness's own maps are too
+small to apply the pressure that would make a pointer worth following. A pointer that fires
+on a two-ticket fixture may be skipped on a nineteen-ticket map, and the harness would not
+see it.
+
+## 6. Only one branch per session, and only the first move
+
+The report is built from a single-turn `-p` run. It sees the session's opening move on the
+branch and nothing after it. A reference that Caesar would reach for on turn six — mid-grill,
+after a landing, at the merge gate — is invisible, because the session never gets a turn six.
+
+## 7. Markers judge the text, not the behaviour
+
+`expect_markers` are regexes over the session's final message. A session that says the right
+words and would have done the wrong thing scores as fired. A session that does the right
+thing in different words scores as not fired. Both have to be read by a human before the
+column means anything.
+
+## 8. It watches the installed skill, not the working tree
+
+The observed file is whatever `~/.claude/skills/caesar` resolves to — a junction onto one
+checkout's `skill/` directory. A branch under test has to be installed (or the junction
+re-pointed) before the harness sees it. The runner prints the roots it is watching on every
+run; if that path is not the branch you meant to test, the whole report is about a different
+file.
+
+## 9. Paths are matched, not file identity
+
+Reads are attributed by string-prefix match against the known skill roots. A session that
+reaches a reference by some path the runner does not know about — a copy, a different
+checkout, a `gh` fetch of the file from GitHub — is not counted, and the report will
+under-report rather than error.
+
+## 10. Fixture issues are closed, not deleted
+
+Cleanup closes the issues and comments why; it does not delete them. They stay in the repo's
+issue history, labelled `caesar:fixture` and titled `[FIXTURE <id>]`. That is deliberate —
+deletion needs `gh api --method DELETE`, which every Caesar deny list blocks — but it means
+the issue numbering of the real map has fixture-shaped gaps in it forever.

--- a/scripts/branch-fixtures/01-chart.json
+++ b/scripts/branch-fixtures/01-chart.json
@@ -1,0 +1,13 @@
+{
+  "id": "chart",
+  "branch": "Chart a new map",
+  "situation": "Caesar is handed a loose idea and no map URL. The branch is forced by the absence of a map, not by asking the session to chart one: there is nothing to sweep, so 'Charting a new map' is the only section that applies.",
+  "map": null,
+  "tickets": [],
+  "invocation": "I want to get the Caesar run logs off this machine and somewhere I can read them from my phone. No idea what that looks like yet. Take it.",
+  "expect_reads": [],
+  "expect_markers": [
+    "chart|destination|not yet specified|fog"
+  ],
+  "notes": "expect_reads is empty on purpose. Today's SKILL.md carries no reference pointer in its charting section, so a read here would be the session improvising, not a pointer firing. KNOWN NOT TO FIRE on the 2026-08-06 baseline: an invocation with no map URL and no mention of Caesar does not match the skill's description, so the session never loaded the skill and simply built the thing itself. That is a harness limitation, not a Caesar defect - the real invocation is the `/caesar` slash command, and this runner deliberately does not use slash commands because a slash command in `-p` swallows the rest of the message. Fixing it means either naming Caesar in the invocation (which weakens 'the branch is the situation, not a question') or teaching the runner to send a slash command safely. Left as-is and reported."
+}

--- a/scripts/branch-fixtures/02-drive-dispatch.json
+++ b/scripts/branch-fixtures/02-drive-dispatch.json
@@ -1,0 +1,40 @@
+{
+  "id": "drive-dispatch",
+  "branch": "Drive, with a dispatch on the frontier",
+  "situation": "The map's frontier holds one unblocked, unassigned, unlabelled-for-HITL AFK ticket. The session is not asked whether it would dispatch; the only takeable work on the map is a dispatch, so composing one is the loop's next step.",
+  "map": {
+    "title": "Get the run logs readable from a phone",
+    "body": "## Destination\n\nA decision on how Caesar's run records reach Raj when he is away from the machine, and the one change that implements it.\n\n## Decisions so far\n\n_None yet._\n\n## Not yet specified\n\n- Whether the logs go to a hosted service at all, or stay on the machine behind a tunnel.\n\n## Notes\n\nFixture map. Created by scripts/branch-harness.ps1. Safe to close.\n"
+  },
+  "tickets": [
+    {
+      "key": "t1",
+      "title": "Survey the options for getting a local log directory readable remotely",
+      "labels": ["wayfinder:research"],
+      "body": "Find out what the realistic options are for reading a local `.claude/caesar-runs/` directory from a phone, and what each costs in setup and in ongoing exposure.\n\n## Done when\n\n- A short written comparison exists on this ticket.\n- One option is recommended, with the reason.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": false,
+      "close": false,
+      "comment": null,
+      "blocked_by": []
+    },
+    {
+      "key": "t2",
+      "title": "Decide the exposure boundary for remote log access",
+      "labels": ["wayfinder:grilling"],
+      "body": "Blocked until the survey lands.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": false,
+      "close": false,
+      "comment": null,
+      "blocked_by": ["t1"]
+    }
+  ],
+  "invocation": "Drive this Wayfinder map: {map_url}",
+  "expect_reads": [
+    "references/prompt-shape.md"
+  ],
+  "expect_markers": [
+    "dispatch|centurion|scout",
+    "heavy|execute|tier"
+  ],
+  "notes": "This is the only branch that today's SKILL.md points at a reference file for. If prompt-shape.md does not appear in the read list here, the observation itself is broken, not the skill."
+}

--- a/scripts/branch-fixtures/03-failure.json
+++ b/scripts/branch-fixtures/03-failure.json
@@ -1,0 +1,37 @@
+{
+  "id": "failure",
+  "branch": "A centurion that failed",
+  "situation": "The map's only AFK ticket is claimed and still open, and it already carries a resolution comment. That is the 'claimed AFK with nothing on disk' shape: the GitHub artifact says the work is done and the bookkeeping is not, so the session lands in the failure rules whether or not it wants to. Nothing on disk is fabricated — the absence of a worktree is what makes it a failure rather than a live run.",
+  "map": {
+    "title": "Trim the startup read set",
+    "body": "## Destination\n\nA decision on which of Caesar's four startup reads can be dropped without losing a failure mode.\n\n## Decisions so far\n\n_None yet._\n\n## Not yet specified\n\n- Whether `gh pr list` can be folded into the frontier sweep.\n\n## Notes\n\nFixture map. Created by scripts/branch-harness.ps1. Safe to close.\n"
+  },
+  "tickets": [
+    {
+      "key": "t1",
+      "title": "Measure what each startup read costs in context",
+      "labels": ["wayfinder:research"],
+      "body": "Measure the context cost of each of the four startup reads on a real map.\n\n## Done when\n\n- A per-read token count is on this ticket.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": true,
+      "close": false,
+      "comment": "## Resolution\n\nMeasured on a 19-child map. The map body read is 6.1K tokens, `frontier.ps1` is 900, `git worktree list` is under 100, and `gh pr list` is under 100. The map body dominates and is the one that is unconditionally required, so none of the four is worth dropping on cost.\n\nGIST: On a 19-child map the map-body read costs 6.1K tokens and the other three startup reads cost under 1.1K combined, so no startup read is worth dropping on context cost.\n",
+      "blocked_by": []
+    },
+    {
+      "key": "t2",
+      "title": "Write the trimmed startup sequence into SKILL.md",
+      "labels": ["wayfinder:task"],
+      "body": "Blocked until the measurement lands.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": false,
+      "close": false,
+      "comment": null,
+      "blocked_by": ["t1"]
+    }
+  ],
+  "invocation": "Drive this Wayfinder map: {map_url}",
+  "expect_reads": [],
+  "expect_markers": [
+    "half.?done|bookkeeping|close (it|the ticket)|finish the mechanical|resolution comment"
+  ],
+  "notes": "The expected call is the 'comment but still open' row: finish the mechanical remainder, no spawn, no flag. The marker deliberately does not demand the word 'failure' — the skill's own wording for this row is about bookkeeping."
+}

--- a/scripts/branch-fixtures/04-veto.json
+++ b/scripts/branch-fixtures/04-veto.json
@@ -1,0 +1,38 @@
+{
+  "id": "veto",
+  "branch": "Raj vetoes a closed decision",
+  "situation": "A decision is closed, commented and written into the map's `## Decisions so far`, and a second open ticket cites it. The invocation is Raj rejecting it in his own words — not a question about what Caesar would do if he did. Raj initiates, which is the one way this branch is allowed to start.",
+  "map": {
+    "title": "Where Caesar's run records live",
+    "body": "## Destination\n\nA decision on where Caesar's per-run records are written and what reads them.\n\n## Decisions so far\n\n- {t1} — Run records stay in `.claude/caesar-runs/` as gitignored machine-bound scratch, because GitHub is already the truth for anything a second checkout needs to read.\n\n## Not yet specified\n\n- Whether the dispatch sidecar should carry the prompt as well as the tier.\n\n## Notes\n\nFixture map. Created by scripts/branch-harness.ps1. Safe to close.\n"
+  },
+  "tickets": [
+    {
+      "key": "t1",
+      "title": "Decide where run records live",
+      "labels": ["wayfinder:grilling"],
+      "body": "Decide whether run records are local scratch or a committed artifact.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": true,
+      "close": true,
+      "comment": "## Resolution\n\nRun records stay under `.claude/caesar-runs/`, gitignored. They are machine-bound and a second checkout cannot read them anyway, so committing them would put a file in the repo that disagrees with GitHub without adding a reader.\n\nGIST: Run records stay in gitignored `.claude/caesar-runs/` scratch rather than being committed, because they are machine-bound and GitHub already carries everything a second checkout needs.\n",
+      "blocked_by": []
+    },
+    {
+      "key": "t2",
+      "title": "Add the tier and cap to the dispatch sidecar",
+      "labels": ["wayfinder:task"],
+      "body": "Follows from {t1}: the sidecar is written beside the result file in the gitignored run directory, so it inherits that decision's location.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": false,
+      "close": false,
+      "comment": null,
+      "blocked_by": []
+    }
+  ],
+  "invocation": "Drive this Wayfinder map: {map_url}\n\nBefore you do anything else: I'm rejecting {t1}. Keeping the run records gitignored is wrong — I want to be able to read what a centurion did from a second checkout, and right now I can't. Unwind that decision.",
+  "expect_reads": [],
+  "expect_markers": [
+    "veto|reject|revers|superseded|unwind",
+    "needs-raj|reopen"
+  ],
+  "notes": "The second ticket cites the first in its body, so `veto-sweep.ps1` has one real dependant to find. This fixture's session is expected to write to the fixture map body — that is the branch working, and the map is disposable."
+}

--- a/scripts/branch-fixtures/05-grill-only.json
+++ b/scripts/branch-fixtures/05-grill-only.json
@@ -1,0 +1,37 @@
+{
+  "id": "grill-only",
+  "branch": "Grill-only with nothing takeable",
+  "situation": "The session is invoked grill-only and the frontier holds two unblocked AFK tickets and no HITL ticket at all. Grill-only spawns nothing, so there is nothing it is permitted to do — the stop is forced by the map's contents, not by asking the session whether it would stop.",
+  "map": {
+    "title": "Retire the hand-poll of the run directory",
+    "body": "## Destination\n\nA decision on what replaces hand-polling `.claude/caesar-runs/`, and the change that lands it.\n\n## Decisions so far\n\n_None yet._\n\n## Not yet specified\n\n- Whether the watcher's quiet timer should be per-map.\n\n## Notes\n\nFixture map. Created by scripts/branch-harness.ps1. Safe to close.\n"
+  },
+  "tickets": [
+    {
+      "key": "t1",
+      "title": "Survey how other harnesses detect a detached agent finishing",
+      "labels": ["wayfinder:research"],
+      "body": "Find out what mechanisms comparable harnesses use to learn that a detached process has finished.\n\n## Done when\n\n- A written comparison is on this ticket.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": false,
+      "close": false,
+      "comment": null,
+      "blocked_by": []
+    },
+    {
+      "key": "t2",
+      "title": "Write the watcher smoke test",
+      "labels": ["wayfinder:task"],
+      "body": "Add a one-pass self-test to the watcher so a re-arm can be shown to replay nothing.\n\n## Done when\n\n- The self-test runs from one command and prints pass or fail.\n\nFixture ticket. Created by scripts/branch-harness.ps1. Safe to close.\n",
+      "assign": false,
+      "close": false,
+      "comment": null,
+      "blocked_by": []
+    }
+  ],
+  "invocation": "Run grill-only on this map: {map_url}",
+  "expect_reads": [],
+  "expect_markers": [
+    "nothing here for me|needs a primary|only afk|nothing.{0,40}permitted|no hitl"
+  ],
+  "notes": "Neither ticket carries `caesar:hitl`, so both are Caesar's own work and unreachable from a grill-only session. The stop line the skill dictates is quoted almost verbatim in the marker."
+}

--- a/scripts/branch-fixtures/README.md
+++ b/scripts/branch-fixtures/README.md
@@ -1,0 +1,29 @@
+# Branch fixtures
+
+One JSON file per fixture. `branch-harness.ps1` globs this directory, so adding a sixth
+branch is dropping a sixth file here — the runner never changes.
+
+## Schema
+
+| Key | Meaning |
+|---|---|
+| `id` | Filename-safe id. `-Fixture <id>` selects it. |
+| `branch` | The Caesar branch this forces, in words. |
+| `situation` | Why this arrangement *is* the branch rather than a question about it. |
+| `map` | `null`, or `{ "title": ..., "body": ... }`. A `null` map means the fixture creates no map — the Chart branch needs the absence of one. |
+| `tickets` | Array of `{ key, title, labels, body, assign, close, comment, blocked_by }`. `key` is referenced from other bodies as `{key}` and substituted with `#<number>` once created. `assign: true` assigns to the authenticated login (a claim). `comment` posts one comment after creation. `blocked_by` lists other `key`s. |
+| `invocation` | The session's first and only user message. `{map_url}` is substituted. Natural language, not `/caesar` — a slash command in `-p` swallows the rest of the message. |
+| `expect_reads` | Reference files the fixture predicts the session will read, as paths relative to the Caesar skill root (e.g. `references/prompt-shape.md`). Empty is a real prediction: today most branches have nothing to point at. |
+| `expect_markers` | Regexes matched case-insensitively against the session's final text. This is how the report knows the branch *fired*, as opposed to the session reading nothing and saying nothing. |
+
+Bodies are plain JSON strings with `\n` escapes and are written to a temp file before
+they reach `gh --body-file`. They never travel through argv.
+
+## Fixture hygiene
+
+Every issue the harness creates is titled `[FIXTURE <id>] ...` and carries the
+`caesar:fixture` label, which the runner creates with `gh label create` first —
+`gh issue create --label` hard-errors on an unknown label and creates nothing.
+
+`branch-harness.ps1 -Cleanup` closes every open `caesar:fixture` issue in the repo and
+comments why. Nothing else in the repo carries that label.

--- a/scripts/branch-harness.ps1
+++ b/scripts/branch-harness.ps1
@@ -1,0 +1,495 @@
+<#
+.SYNOPSIS
+  Drives a real Caesar session against a disposable fixture map, forces one of Caesar's
+  branches, and reports which of the skill's reference files the session actually read.
+
+.DESCRIPTION
+  This is the proof mechanism for the skill-restructure map (#109). Every other ticket on
+  that map changes skill/SKILL.md; this one watches it. A pointer that nobody can see fire
+  is a change nobody can check.
+
+  How the observation works, and why this route:
+
+    - The session is spawned as a headless `claude -p` with an explicit --session-id, so
+      its transcript lands at a path this script computes rather than guesses:
+      ~/.claude/projects/<cwd with [:\/.] replaced by ->/<session-id>.jsonl. That
+      directory derivation is copied from watch-runs.ps1's Get-HeartbeatAge, which is the
+      same lookup; the --session-id half is new, because the watcher only ever needs the
+      newest transcript and this needs a named one.
+    - Every Read/Glob/Grep/Write/Edit in that transcript carries its path in the tool_use
+      block, and Bash command text is scanned too. Paths under either the Caesar skill
+      junction (~/.claude/skills/caesar) or its target (<repo>/skill) normalise to the
+      same skill-relative name, so it does not matter which spelling the session used.
+    - Loading SKILL.md itself is a Skill tool call, not a Read, so it is reported
+      separately as `skill-loaded` rather than as a reference read.
+
+  What this harness cannot see is written down in docs/harness-blind-spots.md. Read it
+  before quoting a result from this script as evidence of anything.
+
+  This script is NOT one of the frozen scripts. It borrows two things by copy and says so
+  here: the deny list and the argv-quoting from spawn-ticket-agent.ps1, and the transcript
+  directory derivation from watch-runs.ps1. Nothing under skill/scripts/ is modified or
+  called for the spawn - spawn-ticket-agent.ps1 hardcodes --permission-mode
+  bypassPermissions, which a nested claude call has auto-denied, so it cannot be reused
+  here.
+
+.EXAMPLE
+  # The whole baseline, all five fixtures, against the installed skill:
+  pwsh -File .\scripts\branch-harness.ps1 -All
+
+.EXAMPLE
+  pwsh -File .\scripts\branch-harness.ps1 -Fixture drive-dispatch
+  pwsh -File .\scripts\branch-harness.ps1 -Cleanup
+#>
+[CmdletBinding(DefaultParameterSetName = 'One')]
+param(
+    [Parameter(Mandatory = $true, ParameterSetName = 'One')][string]$Fixture,
+    [Parameter(Mandatory = $true, ParameterSetName = 'All')][switch]$All,
+    [Parameter(Mandatory = $true, ParameterSetName = 'Cleanup')][switch]$Cleanup,
+    [string]$Repo = 'Dhillvn/Caesar',
+    # Resolved in the body, not here: $PSScriptRoot is not reliably populated inside a
+    # param block's default under `powershell -File <relative path>`.
+    [string]$RepoPath,
+    [string]$FixtureDir,
+    [string]$Model = 'claude-opus-5',
+    [string]$Effort = 'medium',
+    [double]$BudgetUsd = 2.0,
+    [int]$TimeoutMinutes = 25,
+    # Leave the fixture issues open after the run. Off by default: an open fixture map is
+    # indistinguishable from real work in a `gh issue list`, which is the whole reason
+    # they carry a label and a title prefix.
+    [switch]$KeepFixtures
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (-not $RepoPath) { $RepoPath = (Resolve-Path (Split-Path -Parent $scriptDir)).Path }
+if (-not $FixtureDir) { $FixtureDir = Join-Path $scriptDir 'branch-fixtures' }
+
+$FixtureLabel = 'caesar:fixture'
+
+# ---------------------------------------------------------------- skill roots
+
+# Both spellings of the same file. The skill is installed as a junction, so a session may
+# read C:\Users\rajdh\.claude\skills\caesar\references\x.md or
+# C:\Users\rajdh\Projects\caesar\skill\references\x.md and mean the identical byte.
+function Get-SkillRoots {
+    $link = Join-Path $env:USERPROFILE '.claude\skills\caesar'
+    $roots = @()
+    $item = Get-Item -LiteralPath $link -Force -ErrorAction SilentlyContinue
+    if ($item) {
+        $roots += $item.FullName
+        if ($item.LinkType -eq 'Junction') {
+            $t = @($item.Target)[0]
+            if ($t) { $roots += $t }
+        }
+    }
+    $roots += (Join-Path $RepoPath 'skill')
+    ,@($roots | Where-Object { $_ } | Sort-Object -Unique)
+}
+
+function ConvertTo-SkillRelative([string]$Path, [string[]]$Roots) {
+    if (-not $Path) { return $null }
+    $p = ($Path -replace '/', '\')
+    foreach ($r in $Roots) {
+        $rr = ($r -replace '/', '\').TrimEnd('\') + '\'
+        if ($p.StartsWith($rr, [StringComparison]::OrdinalIgnoreCase)) {
+            return ($p.Substring($rr.Length) -replace '\\', '/')
+        }
+    }
+    $null
+}
+
+# ---------------------------------------------------------------- fixtures
+
+function Get-Fixtures {
+    if (-not (Test-Path -LiteralPath $FixtureDir)) { throw "No fixture directory at $FixtureDir" }
+    Get-ChildItem -LiteralPath $FixtureDir -Filter *.json -File | Sort-Object Name | ForEach-Object {
+        # ReadAllText, not Get-Content: a fixture body is multi-line and must not become
+        # an array on the way to ConvertFrom-Json.
+        $f = [IO.File]::ReadAllText($_.FullName) | ConvertFrom-Json
+        $f | Add-Member -NotePropertyName SourceFile -NotePropertyValue $_.FullName -Force
+        $f
+    }
+}
+
+# ---------------------------------------------------------------- github
+
+function Invoke-Gh([string[]]$GhArgs) {
+    # 'Continue' around the call for the same reason as Invoke-GhQuiet: gh's success
+    # chatter goes to stderr, and under 'Stop' that alone terminates the script. The exit
+    # code is the only failure signal that means anything here.
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { $out = & gh @GhArgs 2>&1 } finally { $ErrorActionPreference = $old }
+    if ($LASTEXITCODE -ne 0) { throw "gh $($GhArgs -join ' ') failed: $out" }
+    @($out) | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] }
+}
+
+# gh writes progress lines to stderr on success ("Closed issue ..."). Under
+# $ErrorActionPreference = 'Stop' a native command writing to stderr surfaces as a
+# terminating NativeCommandError, so every fire-and-forget gh call goes through here.
+function Invoke-GhQuiet([string[]]$GhArgs) {
+    $old = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { & gh @GhArgs 2>&1 | Out-Null } finally { $ErrorActionPreference = $old }
+}
+
+function New-BodyFile([string]$Text, [string]$Dir, [string]$Name) {
+    $p = Join-Path $Dir $Name
+    # Bodies reach gh through a file, never argv. WriteAllText names its own encoding and
+    # emits no BOM; Set-Content -Encoding UTF8 on 5.1 would prepend one.
+    [IO.File]::WriteAllText($p, $Text, (New-Object Text.UTF8Encoding $false))
+    $p
+}
+
+function Assert-FixtureLabel {
+    $existing = & gh label list --repo $Repo --limit 200 --json name --jq '.[].name' 2>$null
+    if ($existing -contains $FixtureLabel) { return }
+    # `gh issue create --label` hard-errors on an unknown label and creates nothing, so
+    # this has to happen before any issue does.
+    Invoke-GhQuiet @('label', 'create', $FixtureLabel, '--repo', $Repo, '--color', 'ededed',
+        '--description', 'Disposable issue created by scripts/branch-harness.ps1. Never real work.')
+}
+
+function New-FixtureIssue {
+    param([string]$Title, [string[]]$Labels, [string]$Body, [string]$Dir, [string]$Slug)
+    $bodyFile = New-BodyFile $Body $Dir "$Slug.body.md"
+    $ghArgs = @('issue', 'create', '--repo', $Repo, '--title', $Title, '--body-file', $bodyFile)
+    foreach ($l in @($Labels) + @($FixtureLabel)) { $ghArgs += @('--label', $l) }
+    $url = (Invoke-Gh $ghArgs | Select-Object -Last 1).ToString().Trim()
+    if ($url -notmatch '/issues/(\d+)\s*$') { throw "Could not read an issue number out of: $url" }
+    [pscustomobject]@{ Number = [int]$Matches[1]; Url = $url }
+}
+
+function Get-IssueDbId([int]$Number) {
+    # No space anywhere in the --jq expression, so argv cannot split it.
+    [int64](Invoke-Gh @('api', "repos/$Repo/issues/$Number", '--jq', '.id') | Select-Object -Last 1)
+}
+
+# ---------------------------------------------------------------- transcript
+
+function Get-TranscriptPath([string]$Cwd, [string]$SessionId) {
+    # Copied from watch-runs.ps1 Get-HeartbeatAge - same lookup, named file instead of
+    # newest file.
+    $dir = Join-Path "$env:USERPROFILE\.claude\projects" (($Cwd -replace '/', '\') -replace '[:\\/.]', '-')
+    Join-Path $dir "$SessionId.jsonl"
+}
+
+function Read-TranscriptReads([string]$Path, [string[]]$Roots) {
+    $reads = [System.Collections.ArrayList]::new()
+    $skills = [System.Collections.ArrayList]::new()
+    $tools = [System.Collections.ArrayList]::new()
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return [pscustomobject]@{ Reads = @(); Skills = @(); Tools = @(); Lines = 0 }
+    }
+    $lines = @(Get-Content -LiteralPath $Path -ErrorAction SilentlyContinue)
+    foreach ($line in $lines) {
+        if (-not $line.Trim()) { continue }
+        $e = $null
+        try { $e = $line | ConvertFrom-Json } catch { continue }
+        $content = $e.message.content
+        if ($content -isnot [array]) { continue }
+        foreach ($b in $content) {
+            if ($b.type -ne 'tool_use') { continue }
+            [void]$tools.Add($b.name)
+            if ($b.name -eq 'Skill') { [void]$skills.Add([string]$b.input.skill); continue }
+            $candidates = @($b.input.file_path, $b.input.path, $b.input.pattern, $b.input.notebook_path)
+            if ($b.input.command) {
+                # A session can also reach a reference with `cat`/`Get-Content`. Pull any
+                # windows-ish or posix-ish path out of the command text.
+                $candidates += ([regex]::Matches([string]$b.input.command, '[A-Za-z]:[\\/][^\s"'']+|(?<=\s|^)[\w.\-/\\]*(?:references|skill)[\w.\-/\\]*') |
+                    ForEach-Object { $_.Value })
+            }
+            foreach ($c in $candidates) {
+                $rel = ConvertTo-SkillRelative ([string]$c) $Roots
+                if ($rel) { [void]$reads.Add($rel) }
+            }
+        }
+    }
+    [pscustomobject]@{
+        Reads  = @($reads | Sort-Object -Unique)
+        Skills = @($skills | Sort-Object -Unique)
+        Tools  = @($tools | Group-Object | ForEach-Object { "$($_.Name)x$($_.Count)" } | Sort-Object)
+        Lines  = $lines.Count
+    }
+}
+
+# ---------------------------------------------------------------- the run
+
+# Copied verbatim from spawn-ticket-agent.ps1 (#7). Not imported: that script is frozen
+# and this one runs with a different permission mode, so the two must not share a file.
+$denied = @(
+    'Bash(gh pr merge:*)'
+    'Bash(git merge:*)'
+    'Bash(git push origin main:*)'
+    'Bash(git push --force:*)'
+    'Bash(git push -f:*)'
+    'Bash(git push --force-with-lease:*)'
+    'Bash(git reset --hard:*)'
+    'Bash(git clean -fdx:*)'
+    'Bash(rm -rf:*)'
+    'Bash(gh repo delete:*)'
+    'Bash(gh repo archive:*)'
+    'Bash(gh api --method DELETE:*)'
+    'Bash(gh auth token:*)'
+    'Read(~/.ssh/**)'
+    'Read(**/.env)'
+) + @(
+    # Harness-only. A fixture session must not spawn a real centurion or a nested claude,
+    # and must not delete the fixtures it is being observed against.
+    'Bash(claude:*)'
+    'Bash(gh issue delete:*)'
+)
+
+$harnessFrame = @'
+
+--- harness note, and it is the truth of this machine, not a hypothetical ---
+Dispatching is switched off here: spawn-ticket-agent.ps1 will not run and neither will a
+nested `claude` call. When the loop reaches a dispatch, do everything up to the spawn -
+pick the ticket, pick the tier, compose the dispatch prompt in full - and print the
+prompt instead of firing it. Everything else about this session is normal.
+You have one turn and nothing can wake you, so do not wait on anything.
+'@
+
+function Invoke-FixtureSession {
+    param([string]$Invocation, [string]$Dir, [string]$Slug)
+
+    $sessionId = [guid]::NewGuid().ToString()
+    $promptFile = New-BodyFile ($Invocation + "`n" + $harnessFrame) $Dir "$Slug.prompt.txt"
+    $outFile = Join-Path $Dir "$Slug.result.json"
+    $errFile = Join-Path $Dir "$Slug.err.txt"
+
+    $claudeArgs = @(
+        '-p'
+        '--output-format', 'json'
+        '--session-id', $sessionId
+        '--model', $Model
+        '--effort', $Effort
+        '--max-budget-usd', $BudgetUsd
+        # NOT bypassPermissions: a nested claude call inherits this session's permission
+        # layer, which auto-denies that flag. acceptEdits plus an explicit allow list is
+        # what gets through.
+        '--permission-mode', 'acceptEdits'
+        '--allowedTools', 'Bash', 'Read', 'Glob', 'Grep', 'Write', 'Edit', 'Skill', 'TodoWrite'
+        '--disallowedTools'
+    ) + $denied
+
+    # Quoting copied from spawn-ticket-agent.ps1: Start-Process joins -ArgumentList on
+    # spaces with no quoting of its own, and a deny specifier contains a space, so
+    # unquoted it splits in two and stops matching while still looking present.
+    $cmdLine = ($claudeArgs | ForEach-Object { '"' + ($_ -replace '"', '\"') + '"' }) -join ' '
+
+    $p = Start-Process -FilePath 'claude' -ArgumentList $cmdLine `
+        -WorkingDirectory $RepoPath -WindowStyle Hidden -PassThru `
+        -RedirectStandardInput $promptFile `
+        -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+    $finished = $p.WaitForExit($TimeoutMinutes * 60 * 1000)
+    if (-not $finished) { try { $p.Kill() } catch { } }
+
+    $result = $null
+    if ((Test-Path -LiteralPath $outFile) -and (Get-Item -LiteralPath $outFile).Length -gt 0) {
+        try { $result = [IO.File]::ReadAllText($outFile) | ConvertFrom-Json } catch { $result = $null }
+    }
+
+    [pscustomobject]@{
+        SessionId  = $sessionId
+        TimedOut   = -not $finished
+        Result     = $result
+        ResultFile = $outFile
+        StderrFile = $errFile
+        PromptFile = $promptFile
+        Transcript = (Get-TranscriptPath $RepoPath $sessionId)
+    }
+}
+
+# ---------------------------------------------------------------- fixture staging
+
+function New-FixtureWorld {
+    param($Fx, [string]$Dir)
+
+    $created = [System.Collections.ArrayList]::new()
+    $numbers = @{}
+
+    foreach ($t in @($Fx.tickets)) {
+        $issue = New-FixtureIssue -Title "[FIXTURE $($Fx.id)] $($t.title)" -Labels $t.labels `
+            -Body $t.body -Dir $Dir -Slug "$($Fx.id)-$($t.key)"
+        $numbers[$t.key] = $issue.Number
+        [void]$created.Add($issue)
+    }
+
+    $mapIssue = $null
+    if ($Fx.map) {
+        $mapIssue = New-FixtureIssue -Title "[FIXTURE $($Fx.id)] $($Fx.map.title)" -Labels @('wayfinder:map') `
+            -Body $Fx.map.body -Dir $Dir -Slug "$($Fx.id)-map"
+        [void]$created.Add($mapIssue)
+
+        foreach ($t in @($Fx.tickets)) {
+            $childId = Get-IssueDbId $numbers[$t.key]
+            Invoke-Gh @('api', '--method', 'POST', "repos/$Repo/issues/$($mapIssue.Number)/sub_issues",
+                '-F', "sub_issue_id=$childId") | Out-Null
+        }
+    }
+
+    # Second pass: {key} -> #number, everywhere. Issues need ids before they can reference
+    # each other, so this cannot fold into the creation pass.
+    function Expand-Keys([string]$Text) {
+        foreach ($k in $numbers.Keys) { $Text = $Text -replace ("\{" + [regex]::Escape($k) + "\}"), "#$($numbers[$k])" }
+        $Text
+    }
+
+    if ($mapIssue) {
+        $bf = New-BodyFile (Expand-Keys $Fx.map.body) $Dir "$($Fx.id)-map.final.md"
+        Invoke-Gh @('issue', 'edit', "$($mapIssue.Number)", '--repo', $Repo, '--body-file', $bf) | Out-Null
+    }
+
+    foreach ($t in @($Fx.tickets)) {
+        $n = $numbers[$t.key]
+        if ($t.body -match '\{\w+\}') {
+            $bf = New-BodyFile (Expand-Keys $t.body) $Dir "$($Fx.id)-$($t.key).final.md"
+            Invoke-Gh @('issue', 'edit', "$n", '--repo', $Repo, '--body-file', $bf) | Out-Null
+        }
+        foreach ($b in @($t.blocked_by)) {
+            $blockerId = Get-IssueDbId $numbers[$b]
+            Invoke-Gh @('api', '--method', 'POST', "repos/$Repo/issues/$n/dependencies/blocked_by",
+                '-F', "issue_id=$blockerId") | Out-Null
+        }
+        if ($t.assign) { Invoke-Gh @('issue', 'edit', "$n", '--repo', $Repo, '--add-assignee', '@me') | Out-Null }
+        if ($t.comment) {
+            $cf = New-BodyFile (Expand-Keys $t.comment) $Dir "$($Fx.id)-$($t.key).comment.md"
+            Invoke-Gh @('issue', 'comment', "$n", '--repo', $Repo, '--body-file', $cf) | Out-Null
+        }
+        if ($t.close) { Invoke-Gh @('issue', 'close', "$n", '--repo', $Repo, '--reason', 'completed') | Out-Null }
+    }
+
+    [pscustomobject]@{ Map = $mapIssue; Numbers = $numbers; Created = @($created) }
+}
+
+function Remove-FixtureWorld([object[]]$Issues, [string]$Why) {
+    foreach ($i in @($Issues)) {
+        if (-not $i) { continue }
+        Invoke-GhQuiet @('issue', 'close', "$($i.Number)", '--repo', $Repo, '--reason', 'not planned', '--comment', $Why)
+    }
+}
+
+# ---------------------------------------------------------------- report
+
+function Write-FixtureReport($Row) {
+    $fired = if ($Row.Fired) { 'YES' } else { 'NO ' }
+    Write-Host ''
+    Write-Host "FIXTURE $($Row.Id)  -  $($Row.Branch)"
+    Write-Host "  map          : $(if ($Row.MapUrl) { $Row.MapUrl } else { '(none - branch needs no map)' })"
+    Write-Host "  invocation   : $($Row.Invocation -replace "`r?`n", ' / ')"
+    Write-Host "  branch fired : $fired  $($Row.FiredWhy)"
+    Write-Host "  skill loaded : $(if ($Row.Skills) { $Row.Skills -join ', ' } else { '(none)' })"
+    Write-Host "  read         : $(if ($Row.Reads) { $Row.Reads -join ', ' } else { '(no skill file read)' })"
+    Write-Host "  expected     : $(if ($Row.Expected) { $Row.Expected -join ', ' } else { '(none)' })"
+    Write-Host "  missing      : $(if ($Row.Missing) { $Row.Missing -join ', ' } else { '(none)' })"
+    Write-Host "  also touched : $(if ($Row.Unexpected) { $Row.Unexpected -join ', ' } else { '(none)' })"
+    Write-Host "  run          : is_error=$($Row.IsError) cost=`$$($Row.Cost) turns=$($Row.Turns) transcript_lines=$($Row.TranscriptLines)"
+    Write-Host "  artifacts    : $($Row.Dir)"
+}
+
+# ---------------------------------------------------------------- main
+
+if ($Cleanup) {
+    $open = & gh issue list --repo $Repo --label $FixtureLabel --state open --limit 200 --json number --jq '.[].number'
+    $n = 0
+    foreach ($num in @($open)) {
+        if (-not "$num".Trim()) { continue }
+        Invoke-GhQuiet @('issue', 'close', "$num", '--repo', $Repo, '--reason', 'not planned',
+            '--comment', 'Fixture issue, closed by scripts/branch-harness.ps1 -Cleanup. Never real work.')
+        $n++
+    }
+    Write-Host "Closed $n open $FixtureLabel issue(s) in $Repo."
+    return
+}
+
+$roots = Get-SkillRoots
+Write-Host "Caesar skill roots under observation:"
+$roots | ForEach-Object { Write-Host "  $_" }
+
+# NOT $all - PowerShell is case-insensitive, so that assignment writes the [switch]$All
+# parameter and dies converting an array to a bool.
+$allFixtures = @(Get-Fixtures)
+$selected = if ($All) { $allFixtures } else { @($allFixtures | Where-Object { $_.id -eq $Fixture }) }
+if (-not $selected) { throw "No fixture with id '$Fixture' in $FixtureDir. Have: $(($allFixtures.id) -join ', ')" }
+
+Assert-FixtureLabel
+
+$runId = Get-Date -Format 'yyyyMMdd-HHmmss'
+$runDir = Join-Path $RepoPath ".claude\caesar-runs\branch-harness\$runId"
+New-Item -ItemType Directory -Force -Path $runDir | Out-Null
+
+$rows = foreach ($fx in $selected) {
+    $dir = Join-Path $runDir $fx.id
+    New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    Write-Host "`n=== $($fx.id): $($fx.branch) ==="
+
+    $world = New-FixtureWorld $fx $dir
+    $mapUrl = if ($world.Map) { $world.Map.Url } else { $null }
+    $invocation = $fx.invocation
+    if ($mapUrl) { $invocation = $invocation -replace '\{map_url\}', $mapUrl }
+    foreach ($k in $world.Numbers.Keys) {
+        $invocation = $invocation -replace ("\{" + [regex]::Escape($k) + "\}"), "#$($world.Numbers[$k])"
+    }
+
+    Write-Host "  staged: $(@($world.Created).Count) fixture issue(s). Driving a session..."
+    $run = Invoke-FixtureSession -Invocation $invocation -Dir $dir -Slug $fx.id
+
+    $obs = Read-TranscriptReads $run.Transcript $roots
+    $final = if ($run.Result) { [string]$run.Result.result } else { '' }
+
+    $hit = @()
+    foreach ($m in @($fx.expect_markers)) { if ($final -imatch $m) { $hit += $m } }
+    $fired = ($hit.Count -eq @($fx.expect_markers).Count) -and @($fx.expect_markers).Count -gt 0
+
+    $expected = @($fx.expect_reads)
+    $row = [pscustomobject]@{
+        Id              = $fx.id
+        Branch          = $fx.branch
+        MapUrl          = $mapUrl
+        Invocation      = $invocation
+        Fired           = $fired
+        FiredWhy        = "$($hit.Count)/$(@($fx.expect_markers).Count) marker(s) matched"
+        Skills          = $obs.Skills
+        Reads           = $obs.Reads
+        Expected        = $expected
+        Missing         = @($expected | Where-Object { $obs.Reads -notcontains $_ })
+        # Everything else the session opened inside the skill directory. Not a failure -
+        # a frozen script run out of the skill folder lands here - but it is the column
+        # that would show a pointer firing that no fixture predicted.
+        Unexpected      = @($obs.Reads | Where-Object { $expected -notcontains $_ -and $_ -ne 'SKILL.md' })
+        IsError         = if ($run.Result) { $run.Result.is_error } else { 'no-result' }
+        Cost            = if ($run.Result) { [math]::Round([double]$run.Result.total_cost_usd, 2) } else { 0 }
+        Turns           = if ($run.Result) { $run.Result.num_turns } else { 0 }
+        TimedOut        = $run.TimedOut
+        TranscriptLines = $obs.Lines
+        Transcript      = $run.Transcript
+        FixtureIssues   = @($world.Created | ForEach-Object { $_.Number })
+        Dir             = $dir
+        FinalText       = $final
+    }
+
+    if (-not $KeepFixtures) {
+        Remove-FixtureWorld $world.Created 'Fixture issue, closed by scripts/branch-harness.ps1 after the run. Never real work.'
+    }
+
+    Write-FixtureReport $row
+    $row
+}
+
+$reportFile = Join-Path $runDir 'report.json'
+[IO.File]::WriteAllText($reportFile,
+    ($rows | Select-Object * -ExcludeProperty FinalText | ConvertTo-Json -Depth 6),
+    (New-Object Text.UTF8Encoding $false))
+
+Write-Host ''
+Write-Host '================ per-branch summary ================'
+$rows | Format-Table Id, Fired, @{n='Read';e={ if ($_.Reads) { $_.Reads -join ',' } else { '-' } }},
+    @{n='Expected';e={ if ($_.Expected) { $_.Expected -join ',' } else { '-' } }},
+    @{n='Missing';e={ if ($_.Missing) { $_.Missing -join ',' } else { '-' } }},
+    Cost, IsError -AutoSize
+Write-Host "report: $reportFile"
+Write-Host "blind spots: docs/harness-blind-spots.md  -  read it before quoting any of this."


### PR DESCRIPTION
## What changed

Three things, none of them under `skill/`:

- **`scripts/branch-harness.ps1`** — one command stages disposable fixture issues, drives a real headless Caesar session against them, and prints a per-branch report of which files under the Caesar skill root that session actually opened.
- **`scripts/branch-fixtures/*.json`** — five fixtures, one file each, plus a README carrying the schema. The runner globs the directory, so a sixth branch is a sixth file and no runner change.
- **`docs/harness-blind-spots.md`** — ten things the harness cannot see.

Single documented command:

```
pwsh -File .\scripts\branch-harness.ps1 -All          # the whole baseline
pwsh -File .\scripts\branch-harness.ps1 -Fixture veto # one branch
pwsh -File .\scripts\branch-harness.ps1 -Cleanup      # close every open fixture issue
```

### How a session's reads are observed

The route the ticket suggested holds, with one addition. `spawn-ticket-agent.ps1` runs a headless `claude -p` and the session's transcript records every file it opens — but the watcher only ever needs the *newest* transcript, and a harness needs a *named* one. So the runner spawns with an explicit `--session-id`, which puts the transcript at a path it computes rather than guesses: `~/.claude/projects/<cwd with [:\/.] replaced by ->/<session-id>.jsonl`. The directory derivation is copied from `watch-runs.ps1`'s `Get-HeartbeatAge`.

Proved on a throw-away run before anything was built on it: a haiku session told to read `references/prompt-shape.md` produced exactly one `tool_use` block, `Read {"file_path": "C:\\Users\\rajdh\\.claude\\skills\\caesar\\references\\prompt-shape.md"}`, at the computed path, for $0.03.

Two details that matter for reading the report. Loading `SKILL.md` is a `Skill` tool call, not a `Read`, so it shows in the `skill loaded` column and never as a reference read. And the skill is installed as a junction, so a session may spell the same file `~/.claude/skills/caesar/...` or `<checkout>/skill/...`; both normalise to the same skill-relative name, and the runner prints the roots it is watching on every run.

### `spawn-ticket-agent.ps1` is not reused, and why

It hardcodes `--permission-mode bypassPermissions`, which a nested `claude` call has auto-denied by the parent session's permission layer. The runner therefore spawns its own `claude -p` at `--permission-mode acceptEdits` with an explicit allow list. Two things are **copied, not shared**, and both are commented as copies at the point of use: the deny list from `spawn-ticket-agent.ps1` (plus `Bash(claude:*)` and `Bash(gh issue delete:*)`, harness-only), and its argv-quoting loop. No frozen script is modified or called for the spawn.

## Why

https://github.com/Dhillvn/Caesar/issues/111. This is the proof mechanism for map https://github.com/Dhillvn/Caesar/issues/109: every other ticket on that map edits `skill/SKILL.md`, and a restructure with no way to watch a pointer fire is a change nobody can check.

## Proof it ran — the baseline

All five fixtures, against `skill/SKILL.md` as it stands on `main` (`ab37328`, byte-identical to the junction target the sessions loaded), Opus medium, 2026-08-06. Run `20260806-210945`.

| Fixture | Branch | Fired | Read (skill-relative) | Expected | Missing | Cost |
|---|---|---|---|---|---|---|
| `chart` | Chart a new map | **NO** | `scripts/inspect-run.ps1`, `scripts/publish-runs.ps1`, `scripts/status.ps1`, `scripts/watch-runs.ps1` | — | — | $0.94 |
| `drive-dispatch` | Drive, dispatch on the frontier | YES 2/2 | **`references/prompt-shape.md`**, `scripts/frontier.ps1` | `references/prompt-shape.md` | none | $0.54 |
| `failure` | A centurion that failed | YES 1/1 | `references/prompt-shape.md`, `scripts/frontier.ps1`, `scripts/map-body.ps1` | — | — | $0.88 |
| `veto` | Raj vetoes a closed decision | YES 2/2 | `scripts/frontier.ps1`, `scripts/map-body.ps1`, `scripts/spawn-ticket-agent.ps1`, `scripts/veto-sweep.ps1` | — | — | $1.18 |
| `grill-only` | Grill-only, nothing takeable | YES 1/1 | `scripts/frontier.ps1` | — | — | $0.40 |

Four of five branches fire, no run errored, total $3.94.

**What the baseline establishes.** Today's `SKILL.md` carries exactly one reference pointer, `references/prompt-shape.md`, in the dispatch section — so it is the only file a fixture can predict, and it is the only one that fires. `drive-dispatch` read it, which is the observation working end to end: pointer named in prose → session opened the file → harness saw it. Four empty `expected` columns are not four failures; they are four branches with nothing yet to point at, which is the "nothing disclosed" starting state the restructure will be measured against.

Two things the baseline surfaced that were not predicted, and both are signal rather than noise:

- `failure` read `references/prompt-shape.md` **without any fixture predicting it**. The session picked up the half-done ticket, finished the bookkeeping, and then read the dispatch reference on its way to the *next* ticket. The `also touched` column exists for exactly this: a pointer firing where no fixture expected it.
- `grill-only` stopped verbatim. Its final line was *"No `grilling`, no `prototype`, no HITL `task`. **Nothing here for me — this needs a primary.**"* — the sentence the skill dictates, produced because the map's contents left nothing else legal.

### The fixture that will not fire — `chart`

`chart` is reported as a finding and kept, per the ticket. The invocation is a loose idea with no map URL and no mention of Caesar, which is exactly the branch's situation — but it therefore matches nothing in the skill's `description`, the session never loaded the skill at all, and it simply went and built the thing itself (it wrote a `publish-runs.ps1` into the worktree, which has been deleted; `git status` is clean).

This is a harness limitation, not a Caesar defect. The real invocation is the `/caesar` slash command, and the runner deliberately does not use slash commands because a slash command in `-p` swallows the rest of the message. Fixing it means either naming Caesar in the invocation — which weakens "the fixture must *be* the situation, not a question about it" — or teaching the runner to send a slash command safely. Neither is done here; the finding is recorded in `01-chart.json`'s `notes` and the other four stand.

### Fixture hygiene

Every issue the harness creates is titled `[FIXTURE <id>] ...` and labelled `caesar:fixture`, which the runner creates with `gh label create` first — `gh issue create --label` hard-errors on an unknown label and creates nothing. Cleanup is automatic at the end of each fixture, and `-Cleanup` sweeps any survivor:

```
pwsh -File .\scripts\branch-harness.ps1 -Cleanup
```

It closes every open `caesar:fixture` issue with a comment saying what it was. Run after this baseline; `gh issue list --label caesar:fixture --state open` returns nothing. They are closed, not deleted — deletion needs `gh api --method DELETE`, which every Caesar deny list blocks. Real maps #98 and #109 and their tickets were read and never written to.

## The 1–2 riskiest hunks

1. **`scripts/branch-harness.ps1:262-282`** — the `claude -p` argv construction. The deny list contains specifiers with internal spaces, and `Start-Process` joins `-ArgumentList` on spaces with no quoting of its own, so an unquoted deny list splits and silently stops matching while still looking present. The quoting loop is copied from `spawn-ticket-agent.ps1` for that reason. This is the hunk where the repo's whole silent-failure family lives, and a fault here fails open: the report would still print.
2. **`scripts/branch-harness.ps1:92-102`** — `ConvertTo-SkillRelative`, the string-prefix match that decides whether a path counts as a skill file. A root the runner does not know about makes a read invisible, and the report under-reports rather than erroring. Blind-spot note item 9.

Worth naming as a third: `$all` is not a legal variable name in this script, because PowerShell is case-insensitive and that assignment writes the `[switch]$All` parameter. It cost one run; the variable is `$allFixtures` and carries a comment.

## Blast radius, and reverting

New files only — nothing existing is modified, so nothing that runs today changes behaviour. Revert is `git revert` of one commit, or deleting three paths.

Live blast radius while the harness *runs* is real but bounded: it creates GitHub issues in `Dhillvn/Caesar` and drives a session that can edit them. It is bounded by the label and title prefix (identifiable), automatic cleanup plus `-Cleanup` (disposable), the copied deny list, `Bash(claude:*)` and `Bash(gh issue delete:*)` denied, and a prompt frame telling the session that dispatching is off — which is why the baseline spent $3.94 and spawned no centurion and created no worktree. The frame is itself a blind spot (note item 4): the harness sees the session up to the spawn, never past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
