### PR TITLE
refactor(skill): disclose the ruled regions behind derived pointers (#113)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -48,8 +48,17 @@ the URL. Two roles:
 
 Only one primary at a time.
 
-`/caesar` with a **loose idea and no URL** charts a new map first, then drives it — see
-*Charting a new map* below.
+**Grill-only starts differently** — the two reads it makes, the PR surfacing it must not do,
+and what it says on an AFK-only frontier. Read it when `grill-only` is in the command, before
+your first read: [`references/grill-only.md`](references/grill-only.md).
+
+`/caesar` with a **loose idea and no URL** charts a new map first, then drives it.
+
+**Charting a new map** — the charting sequence: the repo constraint checked first, the `gh`
+recipe for map, tickets, sub-issues and blocking, and fog kept as fog rather than sliced into
+tickets. Read it before you create anything; the `wayfinder:*` labels must already exist in
+the repo or `gh issue create --label` hard-errors and creates nothing:
+[`references/charting.md`](references/charting.md).
 
 ## Starting a session
 
@@ -65,11 +74,19 @@ same truth; only what the sweep *finds* differs.
    corpus behind *you are the smell test*, and it carries the per-map config overrides.
 2. **`scripts/frontier.ps1 -MapUrl <url>`**
 3. **`git worktree list`** — unconditionally, not only when a claimed row appears. The
-   orphan case below is visible only from the disk side. **If it shows a live `ticket-N-*`,
-   arm the watcher before anything else** (see *The watcher*): that centurion was
-   dispatched by a session that is gone, so you are now its only route back to Raj.
+   orphan case is visible only from the disk side. **If it shows a live `ticket-N-*`, arm
+   the watcher before anything else**: that centurion was dispatched by a session that is
+   gone, so you are now its only route back to Raj.
 4. **`gh pr list`** — an open PR awaiting the merge word is the one piece of prior state
    nothing else surfaces. Skip it and a decision of Raj's is silently dropped forever.
+
+**The watcher** — how a landing reaches you, and how to arm it. Arm it here, before anything
+else, when read 3 shows a live `ticket-N-*`; **both Windows paths are quoted or it silently
+watches a directory that does not exist**: [`references/watcher.md`](references/watcher.md).
+
+**Any worktree read 3 shows** — who owns one, how teardown works, and which ones you may
+delete. Read it before you delete anything: **never delete a worktree that is not named
+`ticket-N-*`**, it could be Raj's own: [`references/worktrees.md`](references/worktrees.md).
 
 **No ticket bodies.** Not one, until you have picked a ticket. That is the context killer
 at 19+ children.
@@ -90,31 +107,6 @@ carries information only for AFK tickets.
   claimed, is a session live on it?". No timeout, no staleness heuristic. The failure
   this guards — a crashed grill leaving a ticket assigned forever, shrinking the frontier
   silently — only bites when nothing else is takeable.
-- **Claimed AFK with nothing on disk — check the GitHub artifact, not the disk**, then
-  fall into the failure rules above. Resolution comment but ticket still open →
-  bookkeeping half-done, finish the mechanical remainder yourself. Branch or PR but no
-  comment → *work* half-done, flag it. Nothing at all → nothing ran, re-fire under the
-  retry ceiling. The attempt count is a ticket comment precisely so a session with no
-  local logs can count it — **no new machinery**.
-
-**Assumption, load-bearing and stated: one machine, one checkout per repo.** You are
-always invoked from inside the map's repo and every spawned worktree lives there, so
-`git worktree list` sees every centurion on this map whoever dispatched it — which is
-what makes "no worktree" mean *nothing running* rather than *running where I cannot
-see*. A second machine or checkout breaks the inference.
-
-### Orphan worktrees
-
-`spawn-ticket-agent.ps1` names every worktree `ticket-<number>-<random>`, so provenance is
-stamped into the folder name. **Delete only what you can prove you created and that holds
-nothing.**
-
-| Worktree | Action |
-|---|---|
-| `ticket-N-*`, ticket N closed, teardown succeeds | delete **silently** — one correct outcome, zero information for Raj |
-| `ticket-N-*`, ticket N closed, teardown refuses (dirty/unpushed) | report **once, with the resolution attached** |
-| `ticket-N-*`, ticket N open | not an orphan — that is the live-centurion case |
-| anything not `ticket-N-*` | **never delete.** Could be Raj's own. Report once and ask |
 
 ### What the first turn says
 
@@ -132,97 +124,8 @@ In order, one line each:
 
 On a clean session that is about four lines.
 
-### Grill-only starts differently
-
-**Grill-only reads two things: the map body and `frontier.ps1`.** No `git worktree list`
-and no teardown — it spawns nothing, so it owns nothing on disk, and two grill-only
-sessions auto-deleting orphans is a race on the same folders. No `gh pr list` and **no PR
-surfacing: the primary is the sole surfacer of PRs** — two sessions independently asking
-for the word on the same PR is how it gets double-merged, or worn into a rubber stamp.
-
-If the frontier holds only AFK tickets, grill-only has nothing it is permitted to do. Say
-exactly that — "nothing here for me, this needs a primary" — and stop, rather than sitting
-idle for a reason Raj cannot see.
-
-### Why this is prose and not a script
-
-A script is frozen when its correctness is a flag set that improvisation can silently
-drop. Every dangerous command here is already frozen; the three additions are flagless
-one-liners, and the reconciliation is judgment by definition. A `startup.ps1` would close
-no silent-failure mode. It earns one only if dogfooding shows the startup being skipped or
-costing visible context.
-
-## Charting a new map
-
-Raj arrives with a loose idea and no map. You chart it and then you drive it — charting
-is not a separate session that hands over.
-
-**The repo constraint, checked first.** A map is issues in a git repo: every frozen script
-talks to `gh` against that repo, and `--worktree` is repo-local. So you must be inside a
-git repo with issues enabled. If the idea has no repo, say so plainly and offer to stand
-one up (`gh repo create`, private) as the map's first AFK `task` ticket. Never dead-end on
-it, and never try to host a map in Drive markdown.
-
-Then, in order:
-
-1. **Name the destination.** Grill (`/grilling`, `/domain-modeling`) until it is one or two
-   lines: the spec, decision or change this effort is finding its way to. Scope before
-   route — the destination is what fixes in and out.
-2. **Grill again, breadth-first.** Fan out across the whole space rather than deep on one
-   thread: the open decisions, and the first steps takeable now. **If no fog surfaces** —
-   the way is already clear and the whole thing fits one session — there is nothing to
-   chart. Say so and ask him how he wants to proceed.
-3. **Create the map**, labelled `wayfinder:map`, body in Wayfinder's shape: Destination and
-   Notes filled in, Decisions-so-far empty, the fog in **Not yet specified**.
-4. **Create the tickets** you can specify now, each labelled `wayfinder:<type>`, and attach
-   each to the map as a sub-issue.
-5. **Wire blocking in a second pass** — issues need ids before they can reference each
-   other, so this cannot be folded into step 4.
-
-```
-gh issue create --label wayfinder:map --title "..." --body-file <file>
-gh issue create --label wayfinder:<type> --title "..." --body-file <file>
-gh api repos/<owner>/<repo>/issues/<n> --jq .id
-gh api --method POST repos/<owner>/<repo>/issues/<map>/sub_issues -F sub_issue_id=<child-db-id>
-gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>
-```
-
-Both relationship endpoints take the numeric **database id**, not the `#number` and not the
-`node_id`. Bodies travel **through a file** — a multi-line body dies at the first newline in
-argv.
-
-**The labels must already exist in the target repo.** `gh issue create --label` hard-errors
-on an unknown label and creates nothing — so in a repo that has never held a map, run
-`gh label create wayfinder:map` and one per `wayfinder:<type>` you are about to use, first.
-
-No new script for any of this: these are flagless one-liners and the rest is judgment, the
-same reasoning that kept startup as prose.
-
-**Fog, not pre-sliced tickets.** The test is whether you can *state* the question sharply
-now — not whether you can answer it. Sharp but blocked → a ticket. Not yet sharp → one loose
-line under **Not yet specified**. Do not slice fog into ticket-shaped pieces; one patch may
-graduate into several tickets, or none.
-
-**Declare the shape before you drive.** Name in a line or two what this map will
-actually exercise — two centurions running concurrently, a PR merge gate — and what it
-will not touch. A map that empties without exercising them is a **partial**, and that
-is declared up front, not argued afterwards.
-
-**Then drive.** Do not stop at the handover: name the first ticket you are taking and why,
-and go straight into the loop.
-
-### Why this is not `/wayfinder` in charting mode
-
-Two of its charting instructions contradict locked decisions here, and "follow it except
-those two bits" is exactly the improvisation surface the frozen scripts exist to kill:
-
-- *"Fire the research subagents"* — research tickets go out as headless agents through
-  `spawn-ticket-agent.ps1`, never subagents.
-- *"Stop — charting is one session's work; it hand-resolves nothing"* — charting flows into
-  driving.
-
-Everything else in its charting mode carries over on its merits, and is written out above
-rather than referenced.
+**Startup as prose** — why there is no `startup.ps1`, and what would earn one:
+[`references/design-rationale.md`](references/design-rationale.md).
 
 ## The loop
 
@@ -234,7 +137,7 @@ rather than referenced.
 3. **Grill.** Take one HITL ticket (`grilling`, `prototype`, HITL `task`) and work it
    with Raj in-session. There is no relay and no handoff: subagents cannot converse
    with a human, so you *are* the channel.
-4. **Harvest.** A landing **wakes you** — the watcher below emits one line per event, and
+4. **Harvest.** A landing **wakes you** — the watcher emits one line per event, and
    that line arrives even while you sit idle mid-grill. On each: verify against GitHub,
    append the gist to the map, tear down the worktree.
 5. **Repeat** until the frontier is empty.
@@ -249,318 +152,35 @@ and why**, and let Raj override in a sentence. Judgment beats a priority field.
 Claim before you work: assign the ticket to Raj's GitHub login first, so a concurrent
 session skips it. An open, unassigned ticket is unclaimed.
 
+**Several maps** — discovery, the `caesar:driving` claim, and withdrawal as drain. Read it
+before you search for maps or withdraw from one:
+[`references/multi-map.md`](references/multi-map.md).
+
 ## Dispatching a centurion
 
-`scripts/spawn-ticket-agent.ps1` — one headless `claude -p` process per ticket, each in
-its own git worktree. The script carries the flag set and the deny list; do not compose
-that command by hand.
+**Firing a centurion** — how one goes out: `scripts/spawn-ticket-agent.ps1`, the prompt
+shape, the tier rubric, and how a landing is reported mid-grill. Read it before you fire.
+Never compose the `claude -p` command by hand — the script carries the flag set and the deny
+list — and never treat an exit code as evidence of work done:
+[`references/dispatch.md`](references/dispatch.md).
 
-**Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
-already carries. Read it before you write one; a prompt shaped from memory restates the frame
-and leaves the centurion with no bound of its own:
-[`references/prompt-shape.md`](references/prompt-shape.md).
-
-The centurion **posts its own resolution comment and closes its own ticket**, then prints a
-`GIST:` line. You read only the gist and append it to the map. This keeps your context
-cheap and, more importantly, makes verification real.
-
-**Never treat an exit code as evidence of work done.** A run that silently did nothing
-exits 0 with `is_error: false` and an empty `permission_denials`. Verify against the
-artifact: is the issue closed, does it carry a resolution comment.
-
-**A nested `claude -p --permission-mode bypassPermissions` is auto-denied** by the
-parent session's own permission layer. Dropping the flag lets the nested call through.
-Any ticket whose method spawns sub-agents of its own hits this.
+**The watcher** — how a landing reaches you, and the six events it reports. Arm it once per
+session, at your first dispatch: `spawn-ticket-agent.ps1` detaches and emits no
+`SubagentStop`, so without a watcher a landed centurion reaches nobody until Raj asks:
+[`references/watcher.md`](references/watcher.md).
 
 **Concurrency: 4 centurions, globally, across all maps.** Measured, not chosen —
 8 cores, 15.7 GB with ~2.3 GB free, each at 150–400 MB. It also bounds spend and
 blast radius. Per-ticket spend is capped by `-BudgetUsd` (default 5.0). Both are
 overridable per-map in the map's own **Notes** section.
 
-### The skill block — what the prompt says about skills
-
-A centurion inherits everything an interactive session has: both `CLAUDE.md` files, the
-full skill list, the user-level SessionStart hooks. `--worktree` changes only the working
-directory ([#72](https://github.com/Dhillvn/caesar/blob/main/docs/research/headless-inheritance.md), four probes through the real
-spawn path). So the skill block is an **override layer, not a re-listing** — naming a
-skill the agent already holds is dead weight in every dispatch. Three rules, in order:
-
-**1. Never re-list what is inherited.** Everything in the global `CLAUDE.md` reaches the
-centurion already, including "run `ponytail` before writing code" and caveman mode — #72
-caught a probe writing its own refusal in caveman style, which is that hook acting on a
-headless agent. Retyping those buys nothing, and repetition is not a strengthener:
-whether `ponytail` changes a headless agent's output at all has never been measured.
-
-**2. Never retype an exclusion — the spawn script carries them.** The one banned skill is
-`claude-api`, and the ban lives in the guardrail heredoc in
-`scripts/spawn-ticket-agent.ps1`, where it reaches every centurion and cannot be
-forgotten. **Ban nothing else.** [#73](https://github.com/Dhillvn/caesar/blob/main/docs/research/skill-cost-inventory.md) measured
-all 119 `SKILL.md` files on the machine against several hundred real loads: `SKILL.md`
-size predicts injection at 0.94×, directory size does not predict it at all, and the
-largest ordinary skill is 45 KB — about 6% of the $5.00 cap. `claude-api` injects 898 KB
-(~345K tokens, 147% of the cap) only because its bundle has no `SKILL.md` and inlines its
-whole reference tree. Cost separates that one skill from the population and cannot rank
-the rest against each other, so the old blanket ban on "any other very large reference
-skill" banned cheap skills for nothing and is retired.
-
-For a *new* skill, the test is structural, not size: no `SKILL.md` in its directory, or
-observed injection ≈ its whole directory size. Threshold **100 KB injected**. Re-run
-[`scripts/skill_cost.py`](https://github.com/Dhillvn/caesar/blob/main/scripts/skill_cost.py)
-(the Caesar repo's own `scripts/`, not this skill's) after a Claude Code upgrade:
-`claude-api`'s bundle grew 799 KB → 898 KB in one patch release. Only Raj adds to the ban; a centurion that wants a banned
-skill reads its files off disk.
-
-**3. Name only what the ticket needs and the agent would not reach for.** This is the
-per-ticket judgment and the only part you write by hand — one line, no rationale:
-
-| Ticket shape | Name in the prompt |
-|---|---|
-| design or interface work | `impeccable` |
-| review ticket — written code | `mattpocock-skills:code-review`, with the fixed point in the prompt |
-| review ticket — a plan, not code | `codex-review` (reviews plans, not code, despite the name — [#89](https://github.com/Dhillvn/caesar/issues/89)) |
-| review ticket on the Numen stack (Supabase / Next.js / TS) | also `numen-stack-review` |
-| web retrieval | Firecrawl — `ToolSearch` for its tools first, they arrive deferred |
-| research past ~5 sources | **nothing — read the sources directly** |
-
-**The NotebookLM expectation is retired, not forgotten.** Never write "have NotebookLM
-ingest the sources" into a prompt. If a ticket wants the notebook anyway, its preflight is
-`auth check --test` or the real query, and failure is a fallback to reading the sources
-directly, not a ticket-ending error.
-
-What paid for that rule:
-[#74](https://github.com/Dhillvn/caesar/blob/main/docs/research/notebooklm-headless.md) measured it from inside a real centurion.
-Query and ingest are both programmatically capable and neither is blocked by the deny
-list, but both ride browser cookies Google expires server-side (~10 days observed),
-renewable only by a human signing into a Chromium window — `auth refresh` cannot do it
-headless. Worse, `notebooklm auth check` reports *"Authentication is valid"* on a dead
-session, so a centurion believes it has access and fails downstream.
-
-### The dispatch rubric — which tier
-
-Every dispatch picks a **tier**, passed as `-Tier` to `spawn-ticket-agent.ps1`. The rubric
-governs **dispatched agents only** — `wayfinder:research` tickets and AFK `wayfinder:task`
-tickets. Grilling and prototype tickets are HITL, worked by you and Raj in session, and
-never reach it.
-
-Tiers are **named pairs**, not a model dial crossed with an effort dial. Independent dials
-would be twelve combinations and an argument at every dispatch.
-
-| Tier | Model | Effort | When |
-|---|---|---|---|
-| **Heavy** | `claude-opus-5` | `medium` | The ticket says *figure out*. Design, forensics, research whose method is open. The thinking is the deliverable. |
-| **Execute** | `claude-sonnet-5` | `medium` | The spec is closed. Opus already decided; what remains is carrying it out. |
-| **Tail** | `claude-opus-5` | `high` | Never a dispatch choice. Retry-only (see the failure table) or an explicit per-map override in the map's **Notes**. |
-
-**Default when in doubt: Heavy.** A wrong Heavy call costs the token-price difference. A
-wrong Execute call costs a wasted run plus a re-fire.
-
-**The Execute gate — objective, not a judgment of "well defined".** A ticket is Execute
-**only if its prompt states both**:
-
-1. the files or artifact to produce, by name; and
-2. the check that proves it is done.
-
-If you cannot write both, it is Heavy. This is deliberately a test you can fail, because
-you both write the spec and pick the tier, and the cheap answer is always the one that
-looks like less work.
-
-Why a rubric at all, and why this one: you always run on Opus. You read the map, pick the
-ticket and write the spec — so the *planning* half of the classic Opus-plans /
-Sonnet-executes split is already done, on Opus, before any centurion starts. The centurion
-is the executor. The discriminator is therefore not ticket *type* (which predicts nothing)
-and not a difficulty rating (unfalsifiable), but **whether the thinking has already
-happened**.
-
-**Effort stays `medium` in two tiers of three.** Effort is the larger cost lever — an ~8x
-output-token span low→max against Opus's 1.67x over Sonnet — and it acts on all response
-tokens including tool calls, so higher effort inflates every turn's cache write. Raj runs
-Caesar itself, the hardest role on the machine, at Opus medium and finds it sufficient.
-Published high-effort wins are measured on hard benchmark tasks, not on deliberately
-bite-sized tickets. Holding effort at medium also keeps the rubric to one live dial.
-
-[#64](https://github.com/Dhillvn/caesar/blob/main/docs/research/sonnet-low-reps.md) measured Sonnet-low as 8.8–15.4% cheaper than
-Opus-low at identical (100%) grade, and proposed dropping Execute to `low`. **Raj held it
-at `medium`** on 2026-08-05: the fixtures were sub-$0.45 toy cells against real tickets at
-$1.58–$2.85, so the saving is unproven at working length, and one live dial is worth more
-than a measured single-digit discount. The measurement stands as evidence; the tier does
-not move on it.
-
-**The budget cap does not vary by tier.** Flat **$5.00** for every tier. Sonnet's cheaper
-tokens mean the cap bites less often, not that it should be set lower.
-
-**The tier is written down, not applied silently.** Every dispatch records tier, model,
-effort and the cap actually in force on the run record. A rubric applied silently cannot be
-audited, and a call that cannot be checked against its outcome can never be improved.
-
-Worked examples, from this skill's own map:
-
-| Ticket | Tier | Why |
-|---|---|---|
-| #50 — how does model/effort resolution work | Heavy | Had to design its own probes |
-| #55 — corpus cost analysis | Heavy | Chose its own statistics; found the duplicate-record trap |
-| #58 — published-evidence survey | Heavy | Contradictory sources; the transfer judgment *was* the deliverable |
-| #60 — cap-death forensics | Heavy | Refuted the hypothesis it was handed and rejected the proposed discriminator |
-| #56 — run the remaining probes | Execute | Fixtures and graders already exist; test list enumerated |
-| #52 — build the flags and write the rubric in | Execute | Named script, named parameters, named text |
-| #53 — dogfood two models concurrently | Execute | Acceptance is mechanical |
-
-Note the pattern: **every Execute ticket sits downstream of a resolved decision.**
-
-### The watcher — how a landing reaches you
-
-**Arm it once per session, at your first dispatch**, and leave it up:
-
-```
-Monitor(command: 'powershell -NoProfile -ExecutionPolicy Bypass -File
-        "<skill>\scripts\watch-runs.ps1" -RepoPath "<repo>"',
-        description: 'centurion landings', persistent: true)
-```
-
-**Both Windows paths are quoted, and that is load-bearing.** Monitor runs its command
-through bash, which strips the backslashes out of an unquoted Windows path — so
-`-RepoPath C:\Users\rajdh\Projects\caesar` arrives as `C:UsersrajdhProjectscaesar`, and a
-watcher aimed there can never see a landing. The script now refuses a `-RepoPath` that
-does not exist, emitting `WATCHER-BAD-REPOPATH` and exiting non-zero; before that it
-polled the missing directory in silence and looked healthy for 75 minutes across two real
-landings. **If you see `WATCHER-BAD-REPOPATH`, re-arm with the path quoted** — nothing
-else is wrong.
-
-One watcher covers every centurion on the machine, however many maps dispatched them — do
-not arm one per ticket. It backfills silently on start, so re-arming after a crash replays
-nothing and cannot double-append a gist to the map.
-
-What the watcher is for: `spawn-ticket-agent.ps1` detaches and returns immediately, so a
-finished centurion reaches nothing on its own: no `SubagentStop`, no background-task
-completion, no entry in `claude agents`. Without a watcher your only wake is Raj typing,
-and nothing obliges you to check on that turn — which is how a landed scout sits unreported
-until he asks. **He should never have to ask.**
-
-Six events, and **it returns no verdict** — same as `inspect-run.ps1`:
-
-| Event | What it means |
-|---|---|
-| `LANDED` | result JSON parsed, `GIST:` line carried on the event — verify, then append |
-| `LANDED-NO-GIST` | exit clean, no `GIST:` printed — verify the ticket before appending anything |
-| `ERRORED` | `is_error: true`, with `terminal_reason` and cost |
-| `DIED-AT-SPAWN` | the dispatched process is **gone**, its result file empty, no turn ever written — it definitely never started, and the stderr tail is on the event. Off the clock: it arrives on the next poll |
-| `QUIET` | transcript has not advanced past the timer — **look, do not kill** |
-| `NO-TRANSCRIPT` | past the timer and the session never wrote a turn — it *may* never have started |
-
-`DIED-AT-SPAWN` and `NO-TRANSCRIPT` differ in certainty, and that is the whole distinction:
-the first read the PID from the dispatch sidecar and found nothing alive, so the run is
-terminal and is reported **once**. The second only knows the clock ran out, so it re-arrives
-every `-RecheckMinutes` — the process may yet be alive.
-
-`LANDED` is not "accept the gist" and `QUIET` is not "kill it". The failure table below
-makes both calls, unchanged.
-
-**Never hand-poll the run directory.** The watcher is the only mechanism; a hand-poll only
-fires on a turn you already have, which is the failure this replaces.
-
-### Reporting mid-grill
-
-Default: **one gist line, then straight back to the grill question.** The gist, never
-the title — a title cannot be judged; the gist is the sentence that will represent that
-decision forever, so it is the right unit of review.
-
-Stop the grill only when: the resolution contradicts a locked decision, it drifts
-outside the destination, or the centurion errored. **You are the smell test, not Raj** — you
-hold the whole map and are far better placed to catch a contradiction, which is the
-failure that actually hurts because it silently poisons every downstream ticket.
-
 ## When a centurion fails
 
-**Retry a bad roll, flag a wall. One retry maximum, ever** — then flag regardless of
-class. There is no per-failure-mode policy table to apply: read the evidence and ask
-whether a re-fire could plausibly come out differently. If it could, re-fire once. If
-the same run would hit the same thing again, stop and hand it over.
-
-Look at it with `scripts/inspect-run.ps1` — pipe the spawn result straight in, or pass
-`-ResultFile` alone from a later session. It prints liveness, heartbeat, artifact state,
-the result JSON fields, and the stderr/transcript tails, and **returns no verdict**. The
-call is yours, here:
-
-| What you see | What you do |
-|---|---|
-| **Transient error** — `is_error: true`, stderr shows network / 5xx / rate limit | **Retry** |
-| **Budget exhausted** — cost at cap, no artifact | **Flag.** Raising the cap or splitting the ticket is Raj's call |
-| **Silent do-nothing** — exit 0, `is_error: false`, ticket open, no comment. Includes the clean-exit-mid-wait shape: the centurion built its rig, backgrounded the work, and ended its turn saying it is waiting for a completion notification — nothing wakes a headless agent, so the work finishes after it is gone and is thrown away | **Retry**, prompt sharpened to name the missing artifact |
-| **Half-done** — comment but not closed, or closed with no comment | **Neither.** Finish the mechanical remainder yourself, no spawn. Flag only if the *work* is partial rather than the bookkeeping |
-| **Died at spawn** — `DIED-AT-SPAWN`: the process is gone, nothing was ever written, stderr tail on the event | **Read the tail.** It is the whole diagnosis, and it is nearly always the environment refusing — worktree taken, path missing, auth. Fix the environment and **retry**; if nothing on this machine can be fixed, **flag** |
-| **Wedged** — killed after the heartbeat flatlined | **Triage on the tails.** Died mid-API-call → bad roll → retry. Looping the same action → wall → flag. Never really started (auth, bad path) → wall → flag |
-| **Coherently wrong** — artifact complete, answer collides with a prior decision | **Reopen, comment what it collides with, flag. Never retry** — *except* a complete-but-inadequate artifact at **Execute**, which retries **once at Heavy** |
-
-Wrong never retries because new information may legitimately change Raj's mind — he
-might take the new answer or hold the old one, and you cannot know which. So it goes
-back to him with the collision named, never re-rolled and never resolved on your own
-judgment. The gist does not reach the map either way; you append only after verifying.
-
-**The one licensed exception — escalation is a misclassification remedy, not a failure
-remedy.** It fires on exactly one condition: an Execute run produced a complete artifact
-that is inadequate. That is evidence the Execute gate was called wrong, so the ticket
-re-fires **once at Heavy**. The rule above was written when every run was Opus and the
-model was therefore a constant — a re-roll at the same configuration is the same bet. Once
-the tier can change, a re-fire is a materially different bet, which is what narrowly
-licenses this and nothing else. It applies at Execute only, and it does not raise the one-
-retry maximum.
-
-**Every other failure class retries at the same tier, or does not retry.** In particular,
-**budget death never escalates**: Tail burns the cap faster, so escalating there is
-counting to a tip. **Heavy → Tail never fires automatically** either — Opus medium failing
-does not imply Opus high succeeding, and it costs more. Tail is reached only by an explicit
-per-map override.
-
-**A non-empty `permission_denials` is not a failure signal.** A real successful run on
-disk carries one. Denials count only when no artifact landed.
-
-### The timer: look, do not kill
-
-**At 30 minutes you look; you do not kill.** The clock is the watcher's — a centurion whose
-transcript has not advanced arrives as a `QUIET` event, and re-arrives every 15 minutes
-while it stays quiet, so a wedge cannot go silent again after one notice. You are never the
-one counting; before the watcher existed this rule had no clock at all and so never fired.
-
-On a `QUIET`, read the heartbeat: still moving → the ticket is genuinely long, let it run.
-Not moving → wedged, kill by PID and triage on the tails. A hard kill at the clock bins
-legitimately slow work, and `--max-budget-usd` already bounds a runaway. Both intervals are
-`-QuietMinutes` / `-RecheckMinutes` on the watcher, overridable per-map in the map's
-**Notes**.
-
-A wedge is not automatically a flag — a dropped connection is a bad roll, a loop is a
-wall, and the table above already tells them apart.
-
-**A death is not on the clock at all.** A run whose process is gone before it wrote a turn
-is finished, not slow, so `DIED-AT-SPAWN` arrives on the next poll — seconds, not 30
-minutes — and arrives exactly **once**, because a corpse's state cannot change and a
-repeated alarm on it is how a real landing gets missed. Nothing acknowledges it and nothing
-needs to: re-arming the watcher backfills it silently, the same as a landing.
-
-### Retry mechanics
-
-**Fresh spawn, fresh worktree**, prompt naming what the last attempt left behind ("a
-previous run pushed branch X — continue from it"). Never `--resume`: it carries the
-failed context forward, so a centurion that talked instead of acting resumes talking.
-
-**The attempt count is a comment on the ticket** ("attempt 2 of 2"), not the run logs —
-`.claude/caesar-runs/` is gitignored machine-bound scratch that does not exist for a
-grill-only session on another checkout. GitHub is the truth.
-
-### Flagging: `caesar:needs-raj`
-
-A flagged ticket carries **`caesar:needs-raj`**, **stays assigned**, and gets a comment
-saying why you stopped. Label so the sweep sees it, comment so Raj can read it,
-assignment so it is off the frontier. `frontier.ps1` reports it as `flagged` and
-`status.ps1` renders it **Needs you**, above everything else.
-
-Never leave a failed ticket open and unassigned — that hands it back to the next
-session, which re-fires it, defeating the retry ceiling silently.
-
-The label is per ticket and is not only for failures: it marks **any AFK ticket you have
-stopped on**, including one that finished with an answer you will not accept alone. HITL
-tickets never carry it — Raj is already in the room.
-
-Retries fire **silently**. Flags **queue and surface at a break in the grill**, one line
-each — same as ready PRs, and for the same reason.
+**A centurion that fails** — the failure table: which failures retry, which stamp
+`caesar:needs-raj`, which are Raj's call and not yours, plus the timer, retry mechanics, and
+the claimed-AFK-with-nothing-on-disk case. Read it before you retry, flag or kill; **one
+retry maximum, ever**, and a failure classed from memory is the one that reads as progress:
+[`references/failure.md`](references/failure.md).
 
 ## Showing Raj where things stand
 
@@ -609,70 +229,11 @@ before you write or reword one: [`references/pointer-standard.md`](references/po
 
 ## When Raj vetoes a closed decision
 
-A decision already commented, closed and written into the map, that Raj now rejects.
-
-**Raj initiates.** You may flag doubt about a closed decision and stop — you never
-self-veto. Your reopen power (above) covers an answer he never accepted; it does not
-reach a ruling he made.
-
-**The map must read true.** `## Decisions so far` looks like a history log but it is the
-**session bootstrap** — every future Caesar is taught by it. A reversed line left
-standing is live misinformation. So rewrite the line **in place**: keep the ticket link,
-replace the gist with the reversal and a pointer to what supersedes it. Not struck
-through, not appended below, never deleted. Briefing, not ledger.
-
-**Unwinding is the same act as a flagged failure** — a closed resolution someone will
-not accept is one situation, differing only in who said no. So: **reopen the ticket,
-comment naming what Raj rejected and why, stamp `caesar:needs-raj`.** A veto that
-changes the *question* rather than the answer is not a veto at all; that is ordinary
-charting.
-
-**Sweep one hop, report, reopen nothing.** `scripts/veto-sweep.ps1 -Ticket <url>` lists
-every issue that cross-references the vetoed one. It returns no verdict: separate
-load-bearing dependants from passing citation yourself, propose an action per dependant,
-and wait for his word. A second hop only where hop one came back contaminated.
-
-Do not reach for `gh search issues` — #30 measured it at 12 hits of ~20 against the
-timeline's 5, and the noise reads exactly like a real report. Known gap, accepted: the
-sweep sees only tickets that wrote the link.
-
-**Centurions still in the field are just another class of dependant.** The sweep reports
-them with their PID; drain or kill is Raj's call. No second mechanism.
-
-If the vetoed decision has already shipped, the code half is the merge gate's revert
-(above). This path owns the map-and-ticket half.
-
-## Worktrees
-
-Every centurion gets its own, always — `--worktree` inside the spawn script. Not
-per ticket type: the deciding factor is parallelism, and N processes in one checkout
-collide on `git checkout` no matter what they write.
-
-The centurion renames off the machine-gibberish `worktree-<name>` onto a legible branch, so
-the PR is judgeable. Teardown is `scripts/remove-worktree.ps1`, which is **fail-closed**
-— it will not delete a worktree holding uncommitted or unpushed work.
-
-Report a leftover **once, with the resolution attached**: what happened to the ticket,
-that you have already handled it, where the remains are, and that he can say "bin it".
-A bare "there is a folder here" is unactionable and is a bug in you.
-
-## Holding several maps
-
-A map is yours only while its issue carries **`caesar:driving`**. Discovery is one
-command:
-
-```
-gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving
-```
-
-`--owner` is mandatory — a label-only search returns twenty strangers' public maps.
-
-**No state file.** GitHub reports which tickets are assigned and open; `git worktree
-list` reports what is still running. Both are already the truth, so a scratch file
-could only disagree with them.
-
-Withdrawing from a map is **drain, never kill**: centurions in the field finish and post
-their artifacts, nothing new starts.
+**A decision Raj vetoes** — unwinding one already commented, closed and written into the map:
+the reopen-comment-flag sequence and the one-hop `veto-sweep.ps1`. Read it before you touch
+the map. The reversed line in `## Decisions so far` is rewritten **in place** — never struck
+through, appended below or deleted — because that section is the session bootstrap:
+[`references/veto.md`](references/veto.md).
 
 ## Writing to the map
 

--- a/skill/references/charting.md
+++ b/skill/references/charting.md
@@ -1,0 +1,76 @@
+# Charting a new map
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): the path
+`/caesar` takes when Raj arrives with a loose idea and no map URL.
+
+## Charting a new map
+
+Raj arrives with a loose idea and no map. You chart it and then you drive it — charting
+is not a separate session that hands over.
+
+**The repo constraint, checked first.** A map is issues in a git repo: every frozen script
+talks to `gh` against that repo, and `--worktree` is repo-local. So you must be inside a
+git repo with issues enabled. If the idea has no repo, say so plainly and offer to stand
+one up (`gh repo create`, private) as the map's first AFK `task` ticket. Never dead-end on
+it, and never try to host a map in Drive markdown.
+
+Then, in order:
+
+1. **Name the destination.** Grill (`/grilling`, `/domain-modeling`) until it is one or two
+   lines: the spec, decision or change this effort is finding its way to. Scope before
+   route — the destination is what fixes in and out.
+2. **Grill again, breadth-first.** Fan out across the whole space rather than deep on one
+   thread: the open decisions, and the first steps takeable now. **If no fog surfaces** —
+   the way is already clear and the whole thing fits one session — there is nothing to
+   chart. Say so and ask him how he wants to proceed.
+3. **Create the map**, labelled `wayfinder:map`, body in Wayfinder's shape: Destination and
+   Notes filled in, Decisions-so-far empty, the fog in **Not yet specified**.
+4. **Create the tickets** you can specify now, each labelled `wayfinder:<type>`, and attach
+   each to the map as a sub-issue.
+5. **Wire blocking in a second pass** — issues need ids before they can reference each
+   other, so this cannot be folded into step 4.
+
+```
+gh issue create --label wayfinder:map --title "..." --body-file <file>
+gh issue create --label wayfinder:<type> --title "..." --body-file <file>
+gh api repos/<owner>/<repo>/issues/<n> --jq .id
+gh api --method POST repos/<owner>/<repo>/issues/<map>/sub_issues -F sub_issue_id=<child-db-id>
+gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>
+```
+
+Both relationship endpoints take the numeric **database id**, not the `#number` and not the
+`node_id`. Bodies travel **through a file** — a multi-line body dies at the first newline in
+argv.
+
+**The labels must already exist in the target repo.** `gh issue create --label` hard-errors
+on an unknown label and creates nothing — so in a repo that has never held a map, run
+`gh label create wayfinder:map` and one per `wayfinder:<type>` you are about to use, first.
+
+No new script for any of this: these are flagless one-liners and the rest is judgment, the
+same reasoning that kept startup as prose.
+
+**Fog, not pre-sliced tickets.** The test is whether you can *state* the question sharply
+now — not whether you can answer it. Sharp but blocked → a ticket. Not yet sharp → one loose
+line under **Not yet specified**. Do not slice fog into ticket-shaped pieces; one patch may
+graduate into several tickets, or none.
+
+**Declare the shape before you drive.** Name in a line or two what this map will
+actually exercise — two centurions running concurrently, a PR merge gate — and what it
+will not touch. A map that empties without exercising them is a **partial**, and that
+is declared up front, not argued afterwards.
+
+**Then drive.** Do not stop at the handover: name the first ticket you are taking and why,
+and go straight into the loop.
+
+### Why this is not `/wayfinder` in charting mode
+
+Two of its charting instructions contradict locked decisions here, and "follow it except
+those two bits" is exactly the improvisation surface the frozen scripts exist to kill:
+
+- *"Fire the research subagents"* — research tickets go out as headless agents through
+  `spawn-ticket-agent.ps1`, never subagents.
+- *"Stop — charting is one session's work; it hand-resolves nothing"* — charting flows into
+  driving.
+
+Everything else in its charting mode carries over on its merits, and is written out above
+rather than referenced.

--- a/skill/references/design-rationale.md
+++ b/skill/references/design-rationale.md
@@ -1,0 +1,12 @@
+# Why the startup is prose and not a script
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): a closed
+question, kept so a future pass does not re-litigate it.
+
+### Why this is prose and not a script
+
+A script is frozen when its correctness is a flag set that improvisation can silently
+drop. Every dangerous command here is already frozen; the three additions are flagless
+one-liners, and the reconciliation is judgment by definition. A `startup.ps1` would close
+no silent-failure mode. It earns one only if dogfooding shows the startup being skipped or
+costing visible context.

--- a/skill/references/dispatch.md
+++ b/skill/references/dispatch.md
@@ -1,0 +1,168 @@
+# Dispatching a centurion
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): everything a
+session reads once the sweep hands it an unblocked AFK ticket to fire. The tier vocabulary —
+Heavy, Execute, Tail — is defined here and used by [`failure.md`](failure.md).
+
+## Dispatching a centurion
+
+`scripts/spawn-ticket-agent.ps1` — one headless `claude -p` process per ticket, each in
+its own git worktree. The script carries the flag set and the deny list; do not compose
+that command by hand.
+
+**Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
+already carries. Read it before you write one; a prompt shaped from memory restates the frame
+and leaves the centurion with no bound of its own:
+[`references/prompt-shape.md`](references/prompt-shape.md).
+
+The centurion **posts its own resolution comment and closes its own ticket**, then prints a
+`GIST:` line. You read only the gist and append it to the map. This keeps your context
+cheap and, more importantly, makes verification real.
+
+**Never treat an exit code as evidence of work done.** A run that silently did nothing
+exits 0 with `is_error: false` and an empty `permission_denials`. Verify against the
+artifact: is the issue closed, does it carry a resolution comment.
+
+**A nested `claude -p --permission-mode bypassPermissions` is auto-denied** by the
+parent session's own permission layer. Dropping the flag lets the nested call through.
+Any ticket whose method spawns sub-agents of its own hits this.
+
+### The skill block — what the prompt says about skills
+
+A centurion inherits everything an interactive session has: both `CLAUDE.md` files, the
+full skill list, the user-level SessionStart hooks. `--worktree` changes only the working
+directory ([#72](https://github.com/Dhillvn/caesar/blob/main/docs/research/headless-inheritance.md), four probes through the real
+spawn path). So the skill block is an **override layer, not a re-listing** — naming a
+skill the agent already holds is dead weight in every dispatch. Three rules, in order:
+
+**1. Never re-list what is inherited.** Everything in the global `CLAUDE.md` reaches the
+centurion already, including "run `ponytail` before writing code" and caveman mode — #72
+caught a probe writing its own refusal in caveman style, which is that hook acting on a
+headless agent. Retyping those buys nothing, and repetition is not a strengthener:
+whether `ponytail` changes a headless agent's output at all has never been measured.
+
+**2. Never retype an exclusion — the spawn script carries them.** The one banned skill is
+`claude-api`, and the ban lives in the guardrail heredoc in
+`scripts/spawn-ticket-agent.ps1`, where it reaches every centurion and cannot be
+forgotten. **Ban nothing else.** [#73](https://github.com/Dhillvn/caesar/blob/main/docs/research/skill-cost-inventory.md) measured
+all 119 `SKILL.md` files on the machine against several hundred real loads: `SKILL.md`
+size predicts injection at 0.94×, directory size does not predict it at all, and the
+largest ordinary skill is 45 KB — about 6% of the $5.00 cap. `claude-api` injects 898 KB
+(~345K tokens, 147% of the cap) only because its bundle has no `SKILL.md` and inlines its
+whole reference tree. Cost separates that one skill from the population and cannot rank
+the rest against each other, so the old blanket ban on "any other very large reference
+skill" banned cheap skills for nothing and is retired.
+
+For a *new* skill, the test is structural, not size: no `SKILL.md` in its directory, or
+observed injection ≈ its whole directory size. Threshold **100 KB injected**. Re-run
+[`scripts/skill_cost.py`](https://github.com/Dhillvn/caesar/blob/main/scripts/skill_cost.py)
+(the Caesar repo's own `scripts/`, not this skill's) after a Claude Code upgrade:
+`claude-api`'s bundle grew 799 KB → 898 KB in one patch release. Only Raj adds to the ban; a centurion that wants a banned
+skill reads its files off disk.
+
+**3. Name only what the ticket needs and the agent would not reach for.** This is the
+per-ticket judgment and the only part you write by hand — one line, no rationale:
+
+| Ticket shape | Name in the prompt |
+|---|---|
+| design or interface work | `impeccable` |
+| review ticket — written code | `mattpocock-skills:code-review`, with the fixed point in the prompt |
+| review ticket — a plan, not code | `codex-review` (reviews plans, not code, despite the name — [#89](https://github.com/Dhillvn/caesar/issues/89)) |
+| review ticket on the Numen stack (Supabase / Next.js / TS) | also `numen-stack-review` |
+| web retrieval | Firecrawl — `ToolSearch` for its tools first, they arrive deferred |
+| research past ~5 sources | **nothing — read the sources directly** |
+
+**The NotebookLM expectation is retired, not forgotten.** Never write "have NotebookLM
+ingest the sources" into a prompt. If a ticket wants the notebook anyway, its preflight is
+`auth check --test` or the real query, and failure is a fallback to reading the sources
+directly, not a ticket-ending error.
+
+What paid for that rule:
+[#74](https://github.com/Dhillvn/caesar/blob/main/docs/research/notebooklm-headless.md) measured it from inside a real centurion.
+Query and ingest are both programmatically capable and neither is blocked by the deny
+list, but both ride browser cookies Google expires server-side (~10 days observed),
+renewable only by a human signing into a Chromium window — `auth refresh` cannot do it
+headless. Worse, `notebooklm auth check` reports *"Authentication is valid"* on a dead
+session, so a centurion believes it has access and fails downstream.
+
+### The dispatch rubric — which tier
+
+Every dispatch picks a **tier**, passed as `-Tier` to `spawn-ticket-agent.ps1`. The rubric
+governs **dispatched agents only** — `wayfinder:research` tickets and AFK `wayfinder:task`
+tickets. Grilling and prototype tickets are HITL, worked by you and Raj in session, and
+never reach it.
+
+Tiers are **named pairs**, not a model dial crossed with an effort dial. Independent dials
+would be twelve combinations and an argument at every dispatch.
+
+| Tier | Model | Effort | When |
+|---|---|---|---|
+| **Heavy** | `claude-opus-5` | `medium` | The ticket says *figure out*. Design, forensics, research whose method is open. The thinking is the deliverable. |
+| **Execute** | `claude-sonnet-5` | `medium` | The spec is closed. Opus already decided; what remains is carrying it out. |
+| **Tail** | `claude-opus-5` | `high` | Never a dispatch choice. Retry-only (see the failure table in [`failure.md`](failure.md)) or an explicit per-map override in the map's **Notes**. |
+
+**Default when in doubt: Heavy.** A wrong Heavy call costs the token-price difference. A
+wrong Execute call costs a wasted run plus a re-fire.
+
+**The Execute gate — objective, not a judgment of "well defined".** A ticket is Execute
+**only if its prompt states both**:
+
+1. the files or artifact to produce, by name; and
+2. the check that proves it is done.
+
+If you cannot write both, it is Heavy. This is deliberately a test you can fail, because
+you both write the spec and pick the tier, and the cheap answer is always the one that
+looks like less work.
+
+Why a rubric at all, and why this one: you always run on Opus. You read the map, pick the
+ticket and write the spec — so the *planning* half of the classic Opus-plans /
+Sonnet-executes split is already done, on Opus, before any centurion starts. The centurion
+is the executor. The discriminator is therefore not ticket *type* (which predicts nothing)
+and not a difficulty rating (unfalsifiable), but **whether the thinking has already
+happened**.
+
+**Effort stays `medium` in two tiers of three.** Effort is the larger cost lever — an ~8x
+output-token span low→max against Opus's 1.67x over Sonnet — and it acts on all response
+tokens including tool calls, so higher effort inflates every turn's cache write. Raj runs
+Caesar itself, the hardest role on the machine, at Opus medium and finds it sufficient.
+Published high-effort wins are measured on hard benchmark tasks, not on deliberately
+bite-sized tickets. Holding effort at medium also keeps the rubric to one live dial.
+
+[#64](https://github.com/Dhillvn/caesar/blob/main/docs/research/sonnet-low-reps.md) measured Sonnet-low as 8.8–15.4% cheaper than
+Opus-low at identical (100%) grade, and proposed dropping Execute to `low`. **Raj held it
+at `medium`** on 2026-08-05: the fixtures were sub-$0.45 toy cells against real tickets at
+$1.58–$2.85, so the saving is unproven at working length, and one live dial is worth more
+than a measured single-digit discount. The measurement stands as evidence; the tier does
+not move on it.
+
+**The budget cap does not vary by tier.** Flat **$5.00** for every tier. Sonnet's cheaper
+tokens mean the cap bites less often, not that it should be set lower.
+
+**The tier is written down, not applied silently.** Every dispatch records tier, model,
+effort and the cap actually in force on the run record. A rubric applied silently cannot be
+audited, and a call that cannot be checked against its outcome can never be improved.
+
+Worked examples, from this skill's own map:
+
+| Ticket | Tier | Why |
+|---|---|---|
+| #50 — how does model/effort resolution work | Heavy | Had to design its own probes |
+| #55 — corpus cost analysis | Heavy | Chose its own statistics; found the duplicate-record trap |
+| #58 — published-evidence survey | Heavy | Contradictory sources; the transfer judgment *was* the deliverable |
+| #60 — cap-death forensics | Heavy | Refuted the hypothesis it was handed and rejected the proposed discriminator |
+| #56 — run the remaining probes | Execute | Fixtures and graders already exist; test list enumerated |
+| #52 — build the flags and write the rubric in | Execute | Named script, named parameters, named text |
+| #53 — dogfood two models concurrently | Execute | Acceptance is mechanical |
+
+Note the pattern: **every Execute ticket sits downstream of a resolved decision.**
+
+### Reporting mid-grill
+
+Default: **one gist line, then straight back to the grill question.** The gist, never
+the title — a title cannot be judged; the gist is the sentence that will represent that
+decision forever, so it is the right unit of review.
+
+Stop the grill only when: the resolution contradicts a locked decision, it drifts
+outside the destination, or the centurion errored. **You are the smell test, not Raj** — you
+hold the whole map and are far better placed to catch a contradiction, which is the
+failure that actually hurts because it silently poisons every downstream ticket.

--- a/skill/references/failure.md
+++ b/skill/references/failure.md
@@ -1,0 +1,117 @@
+# When a centurion fails
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): what to do
+when a run errors, dies, goes quiet, or lands an artifact you will not accept. The tier names
+it escalates between are defined in [`dispatch.md`](dispatch.md).
+
+## When a centurion fails
+
+**Retry a bad roll, flag a wall. One retry maximum, ever** — then flag regardless of
+class. There is no per-failure-mode policy table to apply: read the evidence and ask
+whether a re-fire could plausibly come out differently. If it could, re-fire once. If
+the same run would hit the same thing again, stop and hand it over.
+
+Look at it with `scripts/inspect-run.ps1` — pipe the spawn result straight in, or pass
+`-ResultFile` alone from a later session. It prints liveness, heartbeat, artifact state,
+the result JSON fields, and the stderr/transcript tails, and **returns no verdict**. The
+call is yours, here:
+
+| What you see | What you do |
+|---|---|
+| **Transient error** — `is_error: true`, stderr shows network / 5xx / rate limit | **Retry** |
+| **Budget exhausted** — cost at cap, no artifact | **Flag.** Raising the cap or splitting the ticket is Raj's call |
+| **Silent do-nothing** — exit 0, `is_error: false`, ticket open, no comment. Includes the clean-exit-mid-wait shape: the centurion built its rig, backgrounded the work, and ended its turn saying it is waiting for a completion notification — nothing wakes a headless agent, so the work finishes after it is gone and is thrown away | **Retry**, prompt sharpened to name the missing artifact |
+| **Half-done** — comment but not closed, or closed with no comment | **Neither.** Finish the mechanical remainder yourself, no spawn. Flag only if the *work* is partial rather than the bookkeeping |
+| **Died at spawn** — `DIED-AT-SPAWN`: the process is gone, nothing was ever written, stderr tail on the event | **Read the tail.** It is the whole diagnosis, and it is nearly always the environment refusing — worktree taken, path missing, auth. Fix the environment and **retry**; if nothing on this machine can be fixed, **flag** |
+| **Wedged** — killed after the heartbeat flatlined | **Triage on the tails.** Died mid-API-call → bad roll → retry. Looping the same action → wall → flag. Never really started (auth, bad path) → wall → flag |
+| **Coherently wrong** — artifact complete, answer collides with a prior decision | **Reopen, comment what it collides with, flag. Never retry** — *except* a complete-but-inadequate artifact at **Execute**, which retries **once at Heavy** |
+
+Wrong never retries because new information may legitimately change Raj's mind — he
+might take the new answer or hold the old one, and you cannot know which. So it goes
+back to him with the collision named, never re-rolled and never resolved on your own
+judgment. The gist does not reach the map either way; you append only after verifying.
+
+**The one licensed exception — escalation is a misclassification remedy, not a failure
+remedy.** It fires on exactly one condition: an Execute run produced a complete artifact
+that is inadequate. That is evidence the Execute gate was called wrong, so the ticket
+re-fires **once at Heavy**. The rule above was written when every run was Opus and the
+model was therefore a constant — a re-roll at the same configuration is the same bet. Once
+the tier can change, a re-fire is a materially different bet, which is what narrowly
+licenses this and nothing else. It applies at Execute only, and it does not raise the one-
+retry maximum.
+
+**Every other failure class retries at the same tier, or does not retry.** In particular,
+**budget death never escalates**: Tail burns the cap faster, so escalating there is
+counting to a tip. **Heavy → Tail never fires automatically** either — Opus medium failing
+does not imply Opus high succeeding, and it costs more. Tail is reached only by an explicit
+per-map override.
+
+**A non-empty `permission_denials` is not a failure signal.** A real successful run on
+disk carries one. Denials count only when no artifact landed.
+
+### The timer: look, do not kill
+
+**At 30 minutes you look; you do not kill.** The clock is the watcher's — a centurion whose
+transcript has not advanced arrives as a `QUIET` event, and re-arrives every 15 minutes
+while it stays quiet, so a wedge cannot go silent again after one notice. You are never the
+one counting; before the watcher existed this rule had no clock at all and so never fired.
+
+On a `QUIET`, read the heartbeat: still moving → the ticket is genuinely long, let it run.
+Not moving → wedged, kill by PID and triage on the tails. A hard kill at the clock bins
+legitimately slow work, and `--max-budget-usd` already bounds a runaway. Both intervals are
+`-QuietMinutes` / `-RecheckMinutes` on the watcher, overridable per-map in the map's
+**Notes**.
+
+A wedge is not automatically a flag — a dropped connection is a bad roll, a loop is a
+wall, and the table above already tells them apart.
+
+**A death is not on the clock at all.** A run whose process is gone before it wrote a turn
+is finished, not slow, so `DIED-AT-SPAWN` arrives on the next poll — seconds, not 30
+minutes — and arrives exactly **once**, because a corpse's state cannot change and a
+repeated alarm on it is how a real landing gets missed. Nothing acknowledges it and nothing
+needs to: re-arming the watcher backfills it silently, the same as a landing.
+
+### Retry mechanics
+
+**Fresh spawn, fresh worktree**, prompt naming what the last attempt left behind ("a
+previous run pushed branch X — continue from it"). Never `--resume`: it carries the
+failed context forward, so a centurion that talked instead of acting resumes talking.
+
+**The attempt count is a comment on the ticket** ("attempt 2 of 2"), not the run logs —
+`.claude/caesar-runs/` is gitignored machine-bound scratch that does not exist for a
+grill-only session on another checkout. GitHub is the truth.
+
+### Flagging: `caesar:needs-raj`
+
+A flagged ticket carries **`caesar:needs-raj`**, **stays assigned**, and gets a comment
+saying why you stopped. Label so the sweep sees it, comment so Raj can read it,
+assignment so it is off the frontier. `frontier.ps1` reports it as `flagged` and
+`status.ps1` renders it **Needs you**, above everything else.
+
+Never leave a failed ticket open and unassigned — that hands it back to the next
+session, which re-fires it, defeating the retry ceiling silently.
+
+The label is per ticket and is not only for failures: it marks **any AFK ticket you have
+stopped on**, including one that finished with an answer you will not accept alone. HITL
+tickets never carry it — Raj is already in the room.
+
+Retries fire **silently**. Flags **queue and surface at a break in the grill**, one line
+each — same as ready PRs, and for the same reason.
+
+## Reconciling a claimed AFK ticket against the disk
+
+The other half of `SKILL.md`'s *Reconciling GitHub against the disk*; the half every branch
+reads stays inline there.
+
+- **Claimed AFK with nothing on disk — check the GitHub artifact, not the disk**, then
+  fall into the failure rules above. Resolution comment but ticket still open →
+  bookkeeping half-done, finish the mechanical remainder yourself. Branch or PR but no
+  comment → *work* half-done, flag it. Nothing at all → nothing ran, re-fire under the
+  retry ceiling. The attempt count is a ticket comment precisely so a session with no
+  local logs can count it — **no new machinery**.
+
+**Assumption, load-bearing and stated: one machine, one checkout per repo.** You are
+always invoked from inside the map's repo and every spawned worktree lives there, so
+`git worktree list` sees every centurion on this map whoever dispatched it — which is
+what makes "no worktree" mean *nothing running* rather than *running where I cannot
+see*. A second machine or checkout breaks the inference.

--- a/skill/references/grill-only.md
+++ b/skill/references/grill-only.md
@@ -1,0 +1,16 @@
+# Grill-only sessions
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): how a
+`grill-only` session starts, and what it is not permitted to do.
+
+### Grill-only starts differently
+
+**Grill-only reads two things: the map body and `frontier.ps1`.** No `git worktree list`
+and no teardown — it spawns nothing, so it owns nothing on disk, and two grill-only
+sessions auto-deleting orphans is a race on the same folders. No `gh pr list` and **no PR
+surfacing: the primary is the sole surfacer of PRs** — two sessions independently asking
+for the word on the same PR is how it gets double-merged, or worn into a rubber stamp.
+
+If the frontier holds only AFK tickets, grill-only has nothing it is permitted to do. Say
+exactly that — "nothing here for me, this needs a primary" — and stop, rather than sitting
+idle for a reason Raj cannot see.

--- a/skill/references/multi-map.md
+++ b/skill/references/multi-map.md
@@ -1,0 +1,22 @@
+# Holding several maps
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): discovery,
+the `caesar:driving` claim, and withdrawal, when more than one map is in play.
+
+## Holding several maps
+
+A map is yours only while its issue carries **`caesar:driving`**. Discovery is one
+command:
+
+```
+gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving
+```
+
+`--owner` is mandatory — a label-only search returns twenty strangers' public maps.
+
+**No state file.** GitHub reports which tickets are assigned and open; `git worktree
+list` reports what is still running. Both are already the truth, so a scratch file
+could only disagree with them.
+
+Withdrawing from a map is **drain, never kill**: centurions in the field finish and post
+their artifacts, nothing new starts.

--- a/skill/references/prompt-shape.md
+++ b/skill/references/prompt-shape.md
@@ -55,8 +55,8 @@ covering every artifact the ticket produces. *"A `git diff` against `main` touch
 deliverable is a PR, name the five things the merge gate wants (`SKILL.md`, *Build work and
 the merge gate*) in the prompt — the centurion cannot see `SKILL.md`.
 
-This part is also the Execute gate. A ticket you can write step 3 and step 4 for is Execute;
-one you cannot is Heavy.
+This part is also the Execute gate ([`dispatch.md`](dispatch.md)). A ticket you can write step
+3 and step 4 for is Execute; one you cannot is Heavy.
 
 **5. `## Constraints` — what stays untouched, and the blast radius.** Files and sections the
 run leaves alone, and the reason where the reason is load-bearing (a parallel branch, a

--- a/skill/references/veto.md
+++ b/skill/references/veto.md
@@ -1,0 +1,39 @@
+# When Raj vetoes a closed decision
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): unwinding a
+decision already commented, closed and written into the map.
+
+## When Raj vetoes a closed decision
+
+A decision already commented, closed and written into the map, that Raj now rejects.
+
+**Raj initiates.** You may flag doubt about a closed decision and stop — you never
+self-veto. Your reopen power (the failure table in [`failure.md`](failure.md)) covers an
+answer he never accepted; it does not reach a ruling he made.
+
+**The map must read true.** `## Decisions so far` looks like a history log but it is the
+**session bootstrap** — every future Caesar is taught by it. A reversed line left
+standing is live misinformation. So rewrite the line **in place**: keep the ticket link,
+replace the gist with the reversal and a pointer to what supersedes it. Not struck
+through, not appended below, never deleted. Briefing, not ledger.
+
+**Unwinding is the same act as a flagged failure** — a closed resolution someone will
+not accept is one situation, differing only in who said no. So: **reopen the ticket,
+comment naming what Raj rejected and why, stamp `caesar:needs-raj`** ([`failure.md`](failure.md)). **A veto that
+changes the *question* rather than the answer is not a veto at all; that is ordinary
+charting.
+
+**Sweep one hop, report, reopen nothing.** `scripts/veto-sweep.ps1 -Ticket <url>` lists
+every issue that cross-references the vetoed one. It returns no verdict: separate
+load-bearing dependants from passing citation yourself, propose an action per dependant,
+and wait for his word. A second hop only where hop one came back contaminated.
+
+Do not reach for `gh search issues` — #30 measured it at 12 hits of ~20 against the
+timeline's 5, and the noise reads exactly like a real report. Known gap, accepted: the
+sweep sees only tickets that wrote the link.
+
+**Centurions still in the field are just another class of dependant.** The sweep reports
+them with their PID; drain or kill is Raj's call. No second mechanism.
+
+If the vetoed decision has already shipped, the code half is the merge gate's revert
+(`SKILL.md`, *Build work and the merge gate*). This path owns the map-and-ticket half.

--- a/skill/references/watcher.md
+++ b/skill/references/watcher.md
@@ -1,0 +1,55 @@
+# The watcher
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): how a
+finished centurion reaches you, how the watcher is armed, and the six events it reports.
+
+### The watcher — how a landing reaches you
+
+**Arm it once per session, at your first dispatch**, and leave it up:
+
+```
+Monitor(command: 'powershell -NoProfile -ExecutionPolicy Bypass -File
+        "<skill>\scripts\watch-runs.ps1" -RepoPath "<repo>"',
+        description: 'centurion landings', persistent: true)
+```
+
+**Both Windows paths are quoted, and that is load-bearing.** Monitor runs its command
+through bash, which strips the backslashes out of an unquoted Windows path — so
+`-RepoPath C:\Users\rajdh\Projects\caesar` arrives as `C:UsersrajdhProjectscaesar`, and a
+watcher aimed there can never see a landing. The script now refuses a `-RepoPath` that
+does not exist, emitting `WATCHER-BAD-REPOPATH` and exiting non-zero; before that it
+polled the missing directory in silence and looked healthy for 75 minutes across two real
+landings. **If you see `WATCHER-BAD-REPOPATH`, re-arm with the path quoted** — nothing
+else is wrong.
+
+One watcher covers every centurion on the machine, however many maps dispatched them — do
+not arm one per ticket. It backfills silently on start, so re-arming after a crash replays
+nothing and cannot double-append a gist to the map.
+
+What the watcher is for: `spawn-ticket-agent.ps1` detaches and returns immediately, so a
+finished centurion reaches nothing on its own: no `SubagentStop`, no background-task
+completion, no entry in `claude agents`. Without a watcher your only wake is Raj typing,
+and nothing obliges you to check on that turn — which is how a landed scout sits unreported
+until he asks. **He should never have to ask.**
+
+Six events, and **it returns no verdict** — same as `inspect-run.ps1`:
+
+| Event | What it means |
+|---|---|
+| `LANDED` | result JSON parsed, `GIST:` line carried on the event — verify, then append |
+| `LANDED-NO-GIST` | exit clean, no `GIST:` printed — verify the ticket before appending anything |
+| `ERRORED` | `is_error: true`, with `terminal_reason` and cost |
+| `DIED-AT-SPAWN` | the dispatched process is **gone**, its result file empty, no turn ever written — it definitely never started, and the stderr tail is on the event. Off the clock: it arrives on the next poll |
+| `QUIET` | transcript has not advanced past the timer — **look, do not kill** |
+| `NO-TRANSCRIPT` | past the timer and the session never wrote a turn — it *may* never have started |
+
+`DIED-AT-SPAWN` and `NO-TRANSCRIPT` differ in certainty, and that is the whole distinction:
+the first read the PID from the dispatch sidecar and found nothing alive, so the run is
+terminal and is reported **once**. The second only knows the clock ran out, so it re-arrives
+every `-RecheckMinutes` — the process may yet be alive.
+
+`LANDED` is not "accept the gist" and `QUIET` is not "kill it". The failure table in
+[`failure.md`](failure.md) makes both calls, unchanged.
+
+**Never hand-poll the run directory.** The watcher is the only mechanism; a hand-poll only
+fires on a turn you already have, which is the failure this replaces.

--- a/skill/references/worktrees.md
+++ b/skill/references/worktrees.md
@@ -1,0 +1,31 @@
+# Worktrees
+
+Disclosed from `SKILL.md` ([#113](https://github.com/Dhillvn/Caesar/issues/113)): who owns a
+worktree, how one is torn down, and what to do with one you cannot prove you created.
+
+## Worktrees
+
+Every centurion gets its own, always — `--worktree` inside the spawn script. Not
+per ticket type: the deciding factor is parallelism, and N processes in one checkout
+collide on `git checkout` no matter what they write.
+
+The centurion renames off the machine-gibberish `worktree-<name>` onto a legible branch, so
+the PR is judgeable. Teardown is `scripts/remove-worktree.ps1`, which is **fail-closed**
+— it will not delete a worktree holding uncommitted or unpushed work.
+
+Report a leftover **once, with the resolution attached**: what happened to the ticket,
+that you have already handled it, where the remains are, and that he can say "bin it".
+A bare "there is a folder here" is unactionable and is a bug in you.
+
+### Orphan worktrees
+
+`spawn-ticket-agent.ps1` names every worktree `ticket-<number>-<random>`, so provenance is
+stamped into the folder name. **Delete only what you can prove you created and that holds
+nothing.**
+
+| Worktree | Action |
+|---|---|
+| `ticket-N-*`, ticket N closed, teardown succeeds | delete **silently** — one correct outcome, zero information for Raj |
+| `ticket-N-*`, ticket N closed, teardown refuses (dirty/unpushed) | report **once, with the resolution attached** |
+| `ticket-N-*`, ticket N open | not an orphan — that is the live-centurion case |
+| anything not `ticket-N-*` | **never delete.** Could be Raj's own. Report once and ask |


### PR DESCRIPTION
## What changed

`skill/SKILL.md` goes from **800 lines to 361**. Every block the #110 ruling marks **disclose**
moved into `skill/references/`, word for word, and each is reached by one pointer written to the
#112 standard.

Nine new reference files (`dispatch.md`, `failure.md`, `charting.md`, `watcher.md`, `veto.md`,
`worktrees.md`, `multi-map.md`, `grill-only.md`, `design-rationale.md`), each opened by a two-line
`# Title` + provenance header; everything below that header is moved text.

Both mid-section splits were honoured: *Reconciling GitHub against the disk* cut at the
claimed-AFK bullet (inline half stays, disclosed half goes to `failure.md`), and *Dispatching a
centurion* cut before the concurrency cap (cap stays inline, the rest goes to `dispatch.md`).

**Line-count reconciliation.** The ruling measured `main` at `ab37328` (794 lines) and predicted
~320. `main` today is 800: #106 added 2 lines to the disclosed dispatch head and #112 added 4 to
the inline merge gate. So inline was 307, not 303. The remaining 54 lines are pointer material:
**11 pointers, not the ruling's 9** (the watcher takes two firing sites, and `pointer-standard.md`
already had one), most at the **hard** rung the cost table demands, which costs 4–5 lines each
rather than 2, plus three stub `##` headings kept so the document keeps its spine. 307 + 54 = 361.

## Why

Ticket https://github.com/Dhillvn/Caesar/issues/113. #110 ruled what moves; #112 ruled how a
pointer must read; this applies both. Every session now carries 361 lines instead of 800, and the
branch-local material is fetched only by the branches that reach it.

## Proof it ran

**Diff stat**

```
 skill/SKILL.md                       | 800 +---> 361
 skill/references/prompt-shape.md     |   2 +-
 skill/references/charting.md         |  76 ++ (new)
 skill/references/design-rationale.md |  12 ++ (new)
 skill/references/dispatch.md         | 168 ++ (new)
 skill/references/failure.md          | 117 ++ (new)
 skill/references/grill-only.md       |  16 ++ (new)
 skill/references/multi-map.md        |  22 ++ (new)
 skill/references/veto.md             |  39 ++ (new)
 skill/references/watcher.md          |  55 ++ (new)
 skill/references/worktrees.md        |  31 ++ (new)
```

**Text-preservation check (mechanical).** Every non-blank line of `main`'s `SKILL.md` was searched
for verbatim across the new corpus: **590 of 603 survive byte-identical**. The 13 that changed are
exactly the cross-region conversions listed below — no other line of moved or inline text differs.
A separate token check over all 121 backticked spans, 43 numbers/thresholds and 6 URLs in the old
file found **0 missing**: the flag set, the deny list, the tier table, the concurrency cap, the
`$5.00` cap, `100 KB`, `898 KB`/`345K`/`147%`, `0.94×`, `119`, `~10 days`, `8.8–15.4%`, `30`/`15`
minutes, every script name, parameter name, label and issue link.

### Survival inventory

Every rule, threshold, number and named prohibition, with the file and line it now lives on.

| Rule / threshold / prohibition | Now at |
|---|---|
| Flag set + deny list carried by the spawn script | `SKILL.md:163` |
| Concurrency: 4 centurions globally | `SKILL.md:172` |
| `-BudgetUsd` default 5.0 | `SKILL.md:174` |
| `wayfinder:*` labels must pre-exist | `SKILL.md:59` |
| `claude-api` is the one banned skill | `references/dispatch.md:44` |
| **Ban nothing else** | `references/dispatch.md:47` |
| Threshold 100 KB injected | `references/dispatch.md:57` |
| 45 KB largest ordinary skill / ~6% of cap | `references/dispatch.md:50` |
| 898 KB / ~345K tokens / 147% of cap | `references/dispatch.md:50` |
| 0.94× predictor, 119 `SKILL.md` files | `references/dispatch.md:48` |
| Tier table (Heavy / Execute / Tail) | `references/dispatch.md:100` |
| Default when in doubt: Heavy | `references/dispatch.md:104` |
| Execute gate — the two-part test | `references/dispatch.md:107` |
| Effort stays `medium` in two tiers of three | `references/dispatch.md:124` |
| Flat **$5.00** cap for every tier | `references/dispatch.md:138` |
| Tier written down on the run record | `references/dispatch.md:141` |
| Never treat an exit code as evidence | `references/dispatch.md:22` |
| Nested `bypassPermissions` is auto-denied | `references/dispatch.md:26` |
| Never re-list what is inherited | `references/dispatch.md:38` |
| NotebookLM expectation retired | `references/dispatch.md:75` |
| `notebooklm auth check` false-OK | `references/dispatch.md:85` |
| Skill-block ticket-shape table | `references/dispatch.md:68` |
| Gist, never the title | `references/dispatch.md:161` |
| You are the smell test, not Raj | `references/dispatch.md:166` |
| One retry maximum, ever | `references/failure.md:9` |
| Escalation: once at Heavy, Execute only | `references/failure.md:37` |
| Budget death never escalates | `references/failure.md:44` |
| Heavy → Tail never fires automatically | `references/failure.md:45` |
| Coherently wrong never retries | `references/failure.md:27` |
| `permission_denials` is not a failure signal | `references/failure.md:49` |
| At 30 minutes you look, you do not kill | `references/failure.md:54` |
| Re-arrives every 15 minutes | `references/failure.md:55` |
| `-QuietMinutes` / `-RecheckMinutes` | `references/failure.md:62` |
| Never `--resume` | `references/failure.md:77` |
| Attempt count is a ticket comment | `references/failure.md:80` |
| `caesar:needs-raj`: label + assigned + comment | `references/failure.md:86` |
| Never leave a failed ticket open and unassigned | `references/failure.md:91` |
| Both Windows paths quoted (watcher) | `references/watcher.md:16` |
| `WATCHER-BAD-REPOPATH` → re-arm quoted | `references/watcher.md:22` |
| One watcher per machine, not per ticket | `references/watcher.md:25` |
| Six events, returns no verdict | `references/watcher.md:35` |
| Never hand-poll the run directory | `references/watcher.md:54` |
| Numeric database id, not `#number`/`node_id` | `references/charting.md:41` |
| Bodies travel through a file | `references/charting.md:42` |
| Fog, not pre-sliced tickets | `references/charting.md:52` |
| Why this is not `/wayfinder` charting mode | `references/charting.md:65` |
| Never self-veto | `references/veto.md:11` |
| Rewrite in place — not struck, appended or deleted | `references/veto.md:17` |
| Sweep one hop, reopen nothing | `references/veto.md:26` |
| Do not reach for `gh search issues` (12 of ~20 vs 5) | `references/veto.md:31` |
| Never delete a worktree that is not `ticket-N-*` | `references/worktrees.md:31` |
| `remove-worktree.ps1` is fail-closed | `references/worktrees.md:13` |
| Report a leftover once, with the resolution | `references/worktrees.md:16` |
| `--owner` is mandatory on discovery | `references/multi-map.md:15` |
| Withdrawal is drain, never kill | `references/multi-map.md:21` |
| No state file | `references/multi-map.md:17` |
| Grill-only reads two things | `references/grill-only.md:8` |
| Primary is the sole surfacer of PRs | `references/grill-only.md:11` |
| A `startup.ps1` would close no silent-failure mode | `references/design-rationale.md:10` |

### The ten cross-region crossings

Every row of the ruling's dependency table, converted. Conversions are **additive** — a link added,
the sentence's wording preserved — except where a directional word ("above", "below") became false.

| Ruling row | Disposition |
|---|---|
| `:65` *you are the smell test* → *Reporting mid-grill* | **No change.** The sentence asserts something about the map body; it makes no locational claim, and a second link here would give `dispatch.md` two pointers. |
| `:69` startup read 3 → *The watcher* | **Watcher pointer site 1**, at `SKILL.md:83`. "(see *The watcher*)" replaced by the pointer; "the orphan case **below**" → "the orphan case". |
| `:96` "fall into the failure rules above" → *When a centurion fails* | **Resolved by ordering.** The claimed-AFK block is placed *after* the failure rules inside `failure.md`, so "above" stays true and the text is untouched. |
| `:239` loop step 4 "the watcher **below**" → *The watcher* | Directional word dropped. No third pointer. |
| `:350` Tail tier "(see the failure table)" → *When a centurion fails* | Link added: `dispatch.md:102`. |
| `:489`,`:501` "once at Heavy" → tier vocabulary | Named in `failure.md`'s header line (`failure.md:4`), so the tier names resolve without touching the moved rules. |
| `:620` veto "stamp `caesar:needs-raj`" → *Flagging* | Link added: `veto.md:22`. |
| `prompt-shape.md:56` merge gate | **No action** — the merge gate stays inline, as the ruling resolved. |
| `prompt-shape.md:58` "also the Execute gate" | Link added: `prompt-shape.md:58` → `dispatch.md`. |
| `:584` "crossing the Rubicon (see *Voice*)" | **No action** — inline → inline. |

Four crossings the ruling's table did **not** list, found by the end-to-end read and also converted:
`watcher.md:51` "the failure table **below**"; `veto.md:11` "your reopen power **(above)**";
`veto.md:38` "the merge gate's revert **(above)**"; and `SKILL.md:51` "*Charting a new map*
**below**", which became the charting pointer.

### Harness — a smoke check, not a verdict

`scripts/branch-harness.ps1 -All -RepoPath <this worktree>` **completed, exit 0**. Four of five
fixtures fired; `chart` did not, and `references/prompt-shape.md` fired — **identical to #111's
baseline (run `20260806-210945`)**, where `chart` also could not fire without a slash command.

**This is evidence that the harness still runs, not evidence about this restructure.** Per
`docs/harness-blind-spots.md` §8, the sessions load the skill through the junction at
`C:\Users\rajdh\.claude\skills\caesar`, which points at the **main checkout's** working tree, not
this branch — so the file under observation is main's pre-restructure `SKILL.md`. The junction was
left exactly as it was. #115 runs the real verdict after this merges, when the junction picks the
new file up by itself. §1 (a read is not a use), §3 (one roll, not a distribution) and §5 (fixture
maps are two or three children) bound it further.

**One thing the run did that is worth flagging:** while the harness was running, a fixture session
wrote into this worktree — it created `skill/scripts/publish-runs.ps1` and appended an "Off the
machine — the phone view" section to `skill/references/watcher.md`. Neither is in `main`'s
`SKILL.md`, so neither belongs to this ticket. **Both were excluded from this commit**;
`watcher.md` was regenerated from the verified spans and `publish-runs.ps1` is left untracked. The
`chart` fixture's read list also names `references/watcher.md`, a file that exists only on this
branch, which does not sit easily with the junction assumption above — worth a look on #115.

## The 1–2 riskiest hunks

1. **`skill/SKILL.md:96–109`** — *Reconciling GitHub against the disk*, now the inline half only.
   Its opening line still says "Disk evidence carries information only for AFK tickets", but the
   AFK rule itself is now in `failure.md`, reached from `SKILL.md:179`. The ruling flagged this as
   "the ruling most likely to be wrong" — the claimed-AFK case fires on an *ordinary* primary
   sweep, not a rare one. If #115's harness shows the pointer missing on a plain drive, inline the
   whole section again.
2. **`skill/SKILL.md:159–183`** — the two stub sections (*Dispatching a centurion*, *When a
   centurion fails*) that now carry only pointers plus the concurrency cap. These are the two
   highest-cost pointers in the ruling (ranks 1, 2 and 4). If either fails to fire, a `claude -p`
   is composed by hand without the deny list, or no watcher is armed and a landed centurion reaches
   nobody — both silent.

## Blast radius, and whether it is revertable

Confined to `skill/SKILL.md` and `skill/references/`. No script, no `docs/`, no harness fixture is
touched. Nothing executes: the change is what a session reads.

**Fully revertable** — one `git revert` restores the 800-line file, and no state outside the repo
depends on the layout. The live skill is not affected until this merges, because the junction
points at the main checkout.

## Notes for a later ticket

Per the ticket's constraint, moved text keeps its wording; things that read badly after the move
are noted here rather than fixed.

- `charting.md:49` says "the same reasoning that kept startup as prose", whose reasoning is now in
  `design-rationale.md`. No locational claim, so it was left alone.
- `SKILL.md:361` closes with "*The watcher* above replaces the whole item". The watcher pointer is
  indeed above it, so this still resolves, but it reads as a reference to a section that no longer
  exists inline.
- `failure.md:93` ends "same as ready PRs, and for the same reason" — ready PRs are inline in the
  merge gate. No directional word, so untouched.
- The ruling's own recommendation stands: `design-rationale.md` is 8 lines of moved text behind a
  pointer, and deleting the section outright is the honest alternative. That is a content change
  and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*The centurion on #113 authored this body and exhausted its $5 budget at the PR step. Caesar committed the staged work and opened the PR unchanged, after independently re-running the text-preservation check: 590 of 603 non-blank lines byte-identical, the 13 differences exactly the cross-region conversions listed above.*
