### PR TITLE
docs(skill): pair each standing prohibition with its positive target (#114)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,7 +24,8 @@ claude plugin list --json | ConvertFrom-Json |
   Where-Object { Test-Path $_ }
 ```
 
-`installPath` is the version the harness is actually using. Never write a literal path to
+`installPath` is the version the harness is actually using — **run that query each session and
+read Wayfinder from the path it returns.** Never write a literal path to
 Wayfinder and never glob the plugin cache: cache paths carry a version segment and old
 version directories are never removed, so a literal either breaks on the next upstream
 release or — worse, and silently — keeps resolving to a frozen copy while you believe you
@@ -48,8 +49,8 @@ the URL. Two roles:
 
 Only one primary at a time.
 
-**Grill-only starts differently** — the two reads it makes, the PR surfacing it must not do,
-and what it says on an AFK-only frontier. Read it when `grill-only` is in the command, before
+**Grill-only starts differently** — the two reads it makes, the PR surfacing it must not do
+and the primary owns, and what it says on an AFK-only frontier. Read it when `grill-only` is in the command, before
 your first read: [`references/grill-only.md`](references/grill-only.md).
 
 `/caesar` with a **loose idea and no URL** charts a new map first, then drives it.
@@ -86,7 +87,7 @@ watches a directory that does not exist**: [`references/watcher.md`](references/
 
 **Any worktree read 3 shows** — who owns one, how teardown works, and which ones you may
 delete. Read it before you delete anything: **never delete a worktree that is not named
-`ticket-N-*`**, it could be Raj's own: [`references/worktrees.md`](references/worktrees.md).
+`ticket-N-*`** — report it once and ask, it could be Raj's own: [`references/worktrees.md`](references/worktrees.md).
 
 **No ticket bodies.** Not one, until you have picked a ticket. That is the context killer
 at 19+ children.
@@ -142,7 +143,8 @@ On a clean session that is about four lines.
    append the gist to the map, tear down the worktree.
 5. **Repeat** until the frontier is empty.
 
-Never resolve more than one HITL ticket per session. Research tickets are exempt.
+One HITL ticket per session, worked through to a resolution — never resolve more than one
+HITL ticket per session. Research tickets are exempt.
 
 ## Choosing what to work
 
@@ -161,7 +163,7 @@ before you search for maps or withdraw from one:
 **Firing a centurion** — how one goes out: `scripts/spawn-ticket-agent.ps1`, the prompt
 shape, the tier rubric, and how a landing is reported mid-grill. Read it before you fire.
 Never compose the `claude -p` command by hand — the script carries the flag set and the deny
-list — and never treat an exit code as evidence of work done:
+list — and never treat an exit code as evidence of work done; verify against the artifact:
 [`references/dispatch.md`](references/dispatch.md).
 
 **The watcher** — how a landing reaches you, and the six events it reports. Arm it once per
@@ -178,8 +180,9 @@ overridable per-map in the map's own **Notes** section.
 
 **A centurion that fails** — the failure table: which failures retry, which stamp
 `caesar:needs-raj`, which are Raj's call and not yours, plus the timer, retry mechanics, and
-the claimed-AFK-with-nothing-on-disk case. Read it before you retry, flag or kill; **one
-retry maximum, ever**, and a failure classed from memory is the one that reads as progress:
+the claimed-AFK-with-nothing-on-disk case. Read it before you retry, flag or kill, and class
+the failure from the evidence in front of you; **one retry maximum, ever**, and a failure
+classed from memory is the one that reads as progress:
 [`references/failure.md`](references/failure.md).
 
 ## Showing Raj where things stand

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -50,8 +50,8 @@ the URL. Two roles:
 Only one primary at a time.
 
 **Grill-only starts differently** — the two reads it makes, the PR surfacing it must not do
-and the primary owns, and what it says on an AFK-only frontier. Read it when `grill-only` is in the command, before
-your first read: [`references/grill-only.md`](references/grill-only.md).
+and the primary owns, and what it says on an AFK-only frontier. Read it when `grill-only` is
+in the command, before your first read: [`references/grill-only.md`](references/grill-only.md).
 
 `/caesar` with a **loose idea and no URL** charts a new map first, then drives it.
 
@@ -87,7 +87,8 @@ watches a directory that does not exist**: [`references/watcher.md`](references/
 
 **Any worktree read 3 shows** — who owns one, how teardown works, and which ones you may
 delete. Read it before you delete anything: **never delete a worktree that is not named
-`ticket-N-*`** — report it once and ask, it could be Raj's own: [`references/worktrees.md`](references/worktrees.md).
+`ticket-N-*`** — report it once and ask, it could be Raj's own:
+[`references/worktrees.md`](references/worktrees.md).
 
 **No ticket bodies.** Not one, until you have picked a ticket. That is the context killer
 at 19+ children.

--- a/skill/references/dispatch.md
+++ b/skill/references/dispatch.md
@@ -7,8 +7,8 @@ Heavy, Execute, Tail — is defined here and used by [`failure.md`](failure.md).
 ## Dispatching a centurion
 
 `scripts/spawn-ticket-agent.ps1` — one headless `claude -p` process per ticket, each in
-its own git worktree. The script carries the flag set and the deny list; do not compose
-that command by hand.
+its own git worktree. The script carries the flag set and the deny list; fire every dispatch
+through it, and do not compose that command by hand.
 
 **Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
 already carries. Read it before you write one; a prompt shaped from memory restates the frame
@@ -35,7 +35,8 @@ directory ([#72](https://github.com/Dhillvn/caesar/blob/main/docs/research/headl
 spawn path). So the skill block is an **override layer, not a re-listing** — naming a
 skill the agent already holds is dead weight in every dispatch. Three rules, in order:
 
-**1. Never re-list what is inherited.** Everything in the global `CLAUDE.md` reaches the
+**1. Write the block as an override of what the centurion already holds; never re-list what
+is inherited.** Everything in the global `CLAUDE.md` reaches the
 centurion already, including "run `ponytail` before writing code" and caveman mode — #72
 caught a probe writing its own refusal in caveman style, which is that hook acting on a
 headless agent. Retyping those buys nothing, and repetition is not a strengthener:
@@ -44,7 +45,8 @@ whether `ponytail` changes a headless agent's output at all has never been measu
 **2. Never retype an exclusion — the spawn script carries them.** The one banned skill is
 `claude-api`, and the ban lives in the guardrail heredoc in
 `scripts/spawn-ticket-agent.ps1`, where it reaches every centurion and cannot be
-forgotten. **Ban nothing else.** [#73](https://github.com/Dhillvn/caesar/blob/main/docs/research/skill-cost-inventory.md) measured
+forgotten. **Ban nothing else — every other skill on the machine stays available to the
+centurion.** [#73](https://github.com/Dhillvn/caesar/blob/main/docs/research/skill-cost-inventory.md) measured
 all 119 `SKILL.md` files on the machine against several hundred real loads: `SKILL.md`
 size predicts injection at 0.94×, directory size does not predict it at all, and the
 largest ordinary skill is 45 KB — about 6% of the $5.00 cap. `claude-api` injects 898 KB

--- a/skill/references/failure.md
+++ b/skill/references/failure.md
@@ -41,7 +41,8 @@ licenses this and nothing else. It applies at Execute only, and it does not rais
 retry maximum.
 
 **Every other failure class retries at the same tier, or does not retry.** In particular,
-**budget death never escalates**: Tail burns the cap faster, so escalating there is
+**budget death never escalates**: it flags, and raising the cap or splitting the ticket is
+Raj's call. Tail burns the cap faster, so escalating there is
 counting to a tip. **Heavy → Tail never fires automatically** either — Opus medium failing
 does not imply Opus high succeeding, and it costs more. Tail is reached only by an explicit
 per-map override.
@@ -88,7 +89,8 @@ saying why you stopped. Label so the sweep sees it, comment so Raj can read it,
 assignment so it is off the frontier. `frontier.ps1` reports it as `flagged` and
 `status.ps1` renders it **Needs you**, above everything else.
 
-Never leave a failed ticket open and unassigned — that hands it back to the next
+Leave it labelled, assigned and commented, so the sweep passes over it; never leave a
+failed ticket open and unassigned — that hands it back to the next
 session, which re-fires it, defeating the retry ceiling silently.
 
 The label is per ticket and is not only for failures: it marks **any AFK ticket you have

--- a/skill/references/veto.md
+++ b/skill/references/veto.md
@@ -28,7 +28,8 @@ every issue that cross-references the vetoed one. It returns no verdict: separat
 load-bearing dependants from passing citation yourself, propose an action per dependant,
 and wait for his word. A second hop only where hop one came back contaminated.
 
-Do not reach for `gh search issues` — #30 measured it at 12 hits of ~20 against the
+The sweep's hop-one list is the report you work from. Do not reach for `gh search issues` —
+#30 measured it at 12 hits of ~20 against the
 timeline's 5, and the noise reads exactly like a real report. Known gap, accepted: the
 sweep sees only tickets that wrote the link.
 

--- a/skill/references/watcher.md
+++ b/skill/references/watcher.md
@@ -30,7 +30,8 @@ What the watcher is for: `spawn-ticket-agent.ps1` detaches and returns immediate
 finished centurion reaches nothing on its own: no `SubagentStop`, no background-task
 completion, no entry in `claude agents`. Without a watcher your only wake is Raj typing,
 and nothing obliges you to check on that turn — which is how a landed scout sits unreported
-until he asks. **He should never have to ask.**
+until he asks. The armed watcher is what carries the landing to him first: **he should never
+have to ask.**
 
 Six events, and **it returns no verdict** — same as `inspect-run.ps1`:
 
@@ -51,5 +52,6 @@ every `-RecheckMinutes` — the process may yet be alive.
 `LANDED` is not "accept the gist" and `QUIET` is not "kill it". The failure table in
 [`failure.md`](failure.md) makes both calls, unchanged.
 
-**Never hand-poll the run directory.** The watcher is the only mechanism; a hand-poll only
+**Never hand-poll the run directory** — leave the armed watcher to wake you. The watcher is
+the only mechanism; a hand-poll only
 fires on a turn you already have, which is the failure this replaces.


### PR DESCRIPTION
## What changed

A sweep of all twelve skill files — `skill/SKILL.md` and the eleven files in
`skill/references/` — for standing prohibitions, applying the `writing-for-agents` rule that
`references/prompt-shape.md` already teaches in its *Prompt the positive* section: state the
target behaviour, so attention lands on the behaviour to perform rather than on the forbidden
one.

Fourteen prohibitions gained the positive target they protect, in the same breath. **Every
prohibition kept its original wording** — this pass adds, it removes nothing. The rest of the
sweep came back *already compliant* (the passage states the positive beside the prohibition
already) or sits inside frozen content, and is recorded below untouched.

All line numbers below are the branch's.

## Why

https://github.com/Dhillvn/Caesar/issues/114

Steering by prohibition drags the forbidden thing into context and makes it *more* available,
and the negation is a weak modifier over a strongly activated concept. A prohibition earns its
place only as a hard guardrail with no positive phrasing — and even then it is paired with the
positive target in the same breath. `prompt-shape.md` applies this to the prompts Caesar
writes; #114 applies it to the skill Caesar reads.

## Proof it ran

`git diff main --stat`:

```
 skill/SKILL.md               | 22 +++++++++++++---------
 skill/references/dispatch.md | 10 ++++++----
 skill/references/failure.md  |  6 ++++--
 skill/references/veto.md     |  3 ++-
 skill/references/watcher.md  |  6 ++++--
 5 files changed, 29 insertions(+), 18 deletions(-)
```

Confined to `skill/SKILL.md` and `skill/references/`. No script, no `docs/`, no fixture, no
harness run. Two commits: the pairings, then a rewrap of two pointer lines that the first
commit pushed past the file's column width.

Every prohibition that was in `main` is still findable in the branch. Per-file counts of lines
matching `never|do not|don't|must not|no <verb>ing`, `main` against the branch:

| File | `main` | branch |
|---|---|---|
| `SKILL.md` | 24 | 24 |
| `charting.md` | 6 | 6 |
| `dispatch.md` | 10 | 10 |
| `failure.md` | 13 | 13 |
| `multi-map.md` | 1 | 1 |
| `pointer-standard.md` | 7 | 7 |
| `prompt-shape.md` | 8 | 8 |
| `veto.md` | 4 | 4 |
| `watcher.md` | 6 | 6 |
| `worktrees.md` | 1 | 1 |
| `grill-only.md`, `design-rationale.md` | 0 | 0 |

Identical in every file. Nothing was converted away or dropped.

### The prohibition list

**Paired** — the prohibition keeps its wording, the positive target is now beside it.

| File:line | The prohibition | The positive now beside it | Why paired |
|---|---|---|---|
| `skill/SKILL.md:27` | *never write a literal path to Wayfinder and never glob the plugin cache* | **run that query each session and read Wayfinder from the path it returns** | The `powershell` block above was the positive, but it sat two paragraphs up with no instruction attached. The prohibition named two wrong paths and no right one |
| `skill/SKILL.md:52` | *the PR surfacing it must not do* | *…and the primary owns* | A pointer stub. A grill-only session reading only the pointer learned there is a thing it may not do and not who does it instead |
| `skill/SKILL.md:90` | *never delete a worktree that is not named `ticket-N-*`* | **report it once and ask** | Same fact `worktrees.md:31` carries; the pointer named the prohibition without the action that replaces it, so a session that never followed the link had no next move |
| `skill/SKILL.md:147` | *never resolve more than one HITL ticket per session* | **One HITL ticket per session, worked through to a resolution** | The cap read as a ceiling on a count. The behaviour is *take one and finish it*, which the count alone never says |
| `skill/SKILL.md:167` | *never treat an exit code as evidence of work done* | **verify against the artifact** | `dispatch.md:22` pairs this correctly; the pointer carried only the negative half |
| `skill/SKILL.md:184` | *one retry maximum, ever* / *a failure classed from memory is the one that reads as progress* | **class the failure from the evidence in front of you** | A rung-3 pointer whose stub named the failure mode but not the act. `failure.md:9` states the positive; the pointer now shares its word |
| `skill/references/dispatch.md:10` | *do not compose that command by hand* | **fire every dispatch through it** | The script is named in the same sentence; the instruction attached to it was the prohibition only |
| `skill/references/dispatch.md:38` | *never re-list what is inherited* | **Write the block as an override of what the centurion already holds** | The section's own opening line calls the block "an override layer, not a re-listing" — rule 1's heading contradicted that by leading with the negative. The positive is now in the heading, where the model reads it |
| `skill/references/dispatch.md:48` | *Ban nothing else.* | **every other skill on the machine stays available to the centurion** | "Ban nothing else" reads as a limit on an action; the target is the *availability* of the other 118 skills, which #73 paid to establish |
| `skill/references/failure.md:44` | *budget death never escalates* | **it flags, and raising the cap or splitting the ticket is Raj's call** | The table row already said this; the paragraph restating the rule dropped to the negative half, and the paragraph is what a session re-reads |
| `skill/references/failure.md:92` | *never leave a failed ticket open and unassigned* | **Leave it labelled, assigned and commented, so the sweep passes over it** | Three states must hold; the prohibition named the absence of one of them |
| `skill/references/watcher.md:33` | *He should never have to ask.* | **The armed watcher is what carries the landing to him first** | The strongest line in the file named only what must not happen. The mechanism is one clause away and now leads it |
| `skill/references/watcher.md:55` | *Never hand-poll the run directory* | **leave the armed watcher to wake you** | "The watcher is the only mechanism" is a fact about the system, not an instruction to the session. The instruction is now explicit |
| `skill/references/veto.md:31` | *Do not reach for `gh search issues`* | **The sweep's hop-one list is the report you work from** | The tool to use instead was three paragraphs up. The prohibition named the wrong tool at the moment the session is holding the question |

**Already compliant** — the passage already states the positive beside the prohibition. Left
exactly as it is.

| File:line | The prohibition | The positive it already carries |
|---|---|---|
| `SKILL.md:8` | *You are not a general work supervisor* | *You drive **Wayfinder maps*** leads the sentence |
| `SKILL.md:18` | *never by path* | *Resolve it **by name*** leads |
| `SKILL.md:71` | *then stop* | *Four reads, in this order* |
| `SKILL.md:93` | *No ticket bodies. Not one* | *until you have picked a ticket* |
| `SKILL.md:104` | *never touch it, and say nothing* | *One escape: if the frontier comes back empty… name them and ask* |
| `SKILL.md:115` | *not the table* | *It ends with the pick* |
| `SKILL.md:138` | *Do not park them until after the conversation* | *goes out as a centurion **before** you open a grill — up to the cap, queue the rest* |
| `SKILL.md:140` | *There is no relay and no handoff* | *you **are** the channel* |
| `SKILL.md:152` | *There is no scheduler* | *name the map and ticket you are picking and why* |
| `SKILL.md:194` | *no dashboard, no file on Drive, never GitHub's web UI* | *run `scripts/status.ps1 -MapUrl <url>` and show the table* |
| `SKILL.md:200` | *not later* | *stamp it at the moment you open a task that needs his hands* |
| `SKILL.md:205` | *not a refusal* | *The rail is a branch* / *implementation lands as a PR* |
| `SKILL.md:208` | *never on inferred consent* | *Name the PR before you do it* / *`main` changes only on Raj's explicit word* |
| `SKILL.md:212` | *creating no branch and opening no PR* | *Branch discipline is yours to impose around it* |
| `SKILL.md:225` | *interrupting a grill… is how a spot-check degrades into a rubber stamp* | *Ready PRs **queue and land at a break in the grill*** |
| `SKILL.md:238` | *never struck through, appended below or deleted* | *rewritten **in place*** leads |
| `SKILL.md:246` | *no permission specifier can express "don't write to issue #1"* | *that rule is carried in the spawn prompt* |
| `SKILL.md:253` | *Never compose that by hand* | *`scripts/map-body.ps1` is the only way you touch the map body*, same sentence |
| `SKILL.md:261` | *The body must never become a PowerShell value* | *Edit the **file** on disk between the two calls* |
| `SKILL.md:289` | *No Latin, ever* | *only language Raj reads at full speed is eligible* |
| `SKILL.md:305` | *never every message* | *at session open, at the merge gate, and at handback* |
| `SKILL.md:313` | *Do not narrate hedges around a permission you already hold* | *State the action you are already permitted to take*, immediately before |
| `SKILL.md:317` | *no flavour at all* | *Bad news is plain* |
| `SKILL.md:352` | *never make him drive the tracker himself* | *report state in chat, and act on his sentence* |
| `SKILL.md:360` | Away-mode is out of scope | *You wake, you report, you wait* |
| `dispatch.md:14` | *a prompt shaped from memory restates the frame* | *Read it before you write one* |
| `dispatch.md:22` | *Never treat an exit code as evidence of work done* | *Verify against the artifact: is the issue closed, does it carry a resolution comment* — the model for this whole ticket |
| `dispatch.md:26` | *auto-denied* | *Dropping the flag lets the nested call through* — the live example `prompt-shape.md:81` cites |
| `dispatch.md:45` | *Never retype an exclusion* | *the spawn script carries them*, same line |
| `dispatch.md:65` | *Name only what the ticket needs* | positive-form heading already |
| `dispatch.md:75` | *research past ~5 sources → **nothing*** | *read the sources directly* |
| `dispatch.md:77` | *Never write "have NotebookLM ingest the sources"* | *its preflight is `auth check --test` or the real query, and failure is a fallback to reading the sources directly* |
| `dispatch.md:95` | *never reach it* (HITL tickets and the rubric) | *worked by you and Raj in session* |
| `dispatch.md:115` | *If you cannot write both, it is Heavy* | positive default stated |
| `dispatch.md:167` | *Stop the grill only when…* | the three conditions are named |
| `dispatch.md:168` | *not Raj* | *You are the smell test* |
| `failure.md:9` | *One retry maximum, ever* | *Retry a bad roll, flag a wall* / *read the evidence and ask whether a re-fire could plausibly come out differently* |
| `failure.md:27` | *Never retry* (coherently wrong) | *Reopen, comment what it collides with, flag* |
| `failure.md:31` | *never re-rolled and never resolved on your own judgment* | *it goes back to him with the collision named* |
| `failure.md:46` | *Heavy → Tail never fires automatically* | *Tail is reached only by an explicit per-map override* |
| `failure.md:50` | *A non-empty `permission_denials` is not a failure signal* | *Denials count only when no artifact landed* |
| `failure.md:55` | *you do not kill* | *At 30 minutes you look*, same sentence |
| `failure.md:58` | *You are never the one counting* | *The clock is the watcher's* |
| `failure.md:66` | *A wedge is not automatically a flag* | *the table above already tells them apart* |
| `failure.md:72` | *Nothing acknowledges it and nothing needs to* | *re-arming the watcher backfills it silently* |
| `failure.md:78` | *Never `--resume`* | ***Fresh spawn, fresh worktree***, leading the paragraph |
| `failure.md:81` | *not the run logs* | *The attempt count is a comment on the ticket* |
| `failure.md:98` | *HITL tickets never carry it* | *Raj is already in the room* |
| `failure.md:113` | *no new machinery* | *The attempt count is a ticket comment precisely so a session with no local logs can count it* |
| `watcher.md:19` | *a watcher aimed there can never see a landing* | *If you see `WATCHER-BAD-REPOPATH`, re-arm with the path quoted* |
| `watcher.md:26` | *do not arm one per ticket* | *One watcher covers every centurion on the machine*, same sentence |
| `watcher.md:52` | *`LANDED` is not "accept the gist" and `QUIET` is not "kill it"* | *The failure table in `failure.md` makes both calls* |
| `charting.md:23` | *there is nothing to chart* | *Say so and ask him how he wants to proceed* |
| `charting.md:43` | *a multi-line body dies at the first newline in argv* | *Bodies travel **through a file*** |
| `charting.md:50` | *No new script for any of this* | *these are flagless one-liners and the rest is judgment* |
| `charting.md:54` | *Do not slice fog into ticket-shaped pieces* | *Not yet sharp → one loose line under **Not yet specified***, immediately before |
| `charting.md:60` | *not argued afterwards* | *that is declared up front* |
| `charting.md:62` | *Do not stop at the handover* | *name the first ticket you are taking and why, and go straight into the loop* |
| `charting.md:71` | *never subagents* | *research tickets go out as headless agents through `spawn-ticket-agent.ps1`* |
| `worktrees.md:10` | *Not per ticket type* | *the deciding factor is parallelism* |
| `worktrees.md:18` | *A bare "there is a folder here" is unactionable* | *Report a leftover **once, with the resolution attached*** |
| `worktrees.md:24` | *Delete only what you can prove you created* | positive-form already |
| `worktrees.md:31` | *never delete* | *Report once and ask*, same cell |
| `veto.md:11` | *you never self-veto* | ***Raj initiates.** You may flag doubt about a closed decision and stop* |
| `veto.md:17` | *Not struck through, not appended below, never deleted* | *rewrite the line **in place**… keep the ticket link, replace the gist with the reversal* |
| `veto.md:26` | *reopen nothing* | ***Sweep one hop, report***, same line |
| `veto.md:37` | *No second mechanism* | *The sweep reports them with their PID; drain or kill is Raj's call* |
| `multi-map.md:15` | *a label-only search returns twenty strangers' public maps* | *`--owner` is mandatory* |
| `multi-map.md:18` | *No state file* | *GitHub reports which tickets are assigned and open; `git worktree list` reports what is still running* |
| `multi-map.md:22` | *never kill* | ***drain***, same phrase / *centurions in the field finish and post their artifacts* |
| `grill-only.md:9` | *No `git worktree list` and no teardown* | ***Grill-only reads two things: the map body and `frontier.ps1`.*** |
| `grill-only.md:11` | *no PR surfacing* | *the primary is the sole surfacer of PRs*, same sentence |
| `grill-only.md:14` | *rather than sitting idle* | *Say exactly that — "nothing here for me, this needs a primary" — and stop* |
| `prompt-shape.md:18` | *Write them again and you have two authorities for one meaning* | *You write about the frame in one case: to **override** it* |
| `prompt-shape.md:26` | *A part with nothing to say is left out* | *the order of the rest holds* |
| `prompt-shape.md:48` | *Pointing at the ticket for the completion criterion is progressive disclosure applied backwards* | *The prompt **stands alone*** |
| `prompt-shape.md:54` | *"the section reads well" is not* | *"A `git diff` against `main` touches `skill/SKILL.md` and nothing else" is the form* |
| `prompt-shape.md:65` | *doing both is the duplication to remove* | *writing it is usually right* |
| `prompt-shape.md:70` | *so the behaviour you do not want is never named* | *State the target behaviour* — the rule itself |
| `prompt-shape.md:80` | *A prohibition earns its place only as a hard guardrail* | *Pair it with the positive target in the same breath* — the rule this ticket applies |
| `pointer-standard.md:34` | *Prose that also announces where the file lives is the path written twice* | *The link carries the path* |
| `pointer-standard.md:50` | *rather than behind framing like "for more on…"* | *put it in the opening token* |
| `pointer-standard.md:57` | *not a new one* | *reach for an existing one* |
| `pointer-standard.md:72` | *A pointer that also says "this document explains…" buys nothing* | *Cut identity the body already carries* |
| `pointer-standard.md:76` | *then stop* | ***Front-load*** |
| `pointer-standard.md:104` | *Reaching for rung 3 on everything spends the line budget* | *Take the lowest one the cost allows* / *Climb the ladder in that order* |
| `design-rationale.md:11` | *A `startup.ps1` would close no silent-failure mode* | *It earns one only if dogfooding shows the startup being skipped or costing visible context*. Out of scope by constraint; recorded as compliant anyway |

**Frozen content** — the prohibition sits inside the flag set, the deny list, the tier table or
the concurrency cap. Recorded, text untouched.

| File:line | The prohibition | Why frozen |
|---|---|---|
| `dispatch.md:10` | *The script carries the flag set and the deny list* | The flag set and deny list themselves are frozen; only the instruction attached to them was paired |
| `dispatch.md:46` | *The one banned skill is `claude-api`* | The deny list. Its positive — *a centurion that wants a banned skill reads its files off disk* — is already at `dispatch.md:62` |
| `dispatch.md:104` | *Tail — **Never a dispatch choice*** | Inside the tier table. Its positive — *Retry-only… or an explicit per-map override* — is in the same cell |
| `dispatch.md:140` | *The budget cap does not vary by tier* | The cap. Flat $5.00, stated positively already |
| `SKILL.md:175` | ***Concurrency: 4 centurions, globally, across all maps*** | The concurrency cap. Positive-form already |
| `SKILL.md:302` | ***Script names, parameters and variables keep the word `agent`*** | Frozen script names. Positive-form already |
| `prompt-shape.md:14` | *never the map body and never another ticket* | Describes the guardrail heredoc in `scripts/spawn-ticket-agent.ps1` verbatim. Rewording the description desynchronises it from the frozen script |

**Proposed no-op** — the model does the right thing here with no rule at all. **The text is
unchanged**; these are proposals for a later ticket, not this one's edits.

| File:line | The prohibition | Why it may be a no-op |
|---|---|---|
| `charting.md:15` | *Never dead-end on it* | The positive that precedes it — *say so plainly and offer to stand one up (`gh repo create`, private) as the map's first AFK `task` ticket* — is already a complete instruction. A session holding that sentence has no dead-end available to it; the prohibition forbids a behaviour the instruction has already crowded out |
| `charting.md:15` | *never try to host a map in Drive markdown* | The repo constraint is stated as a hard precondition one sentence earlier (*A map is issues in a git repo… `--worktree` is repo-local*). Drive is not a candidate the model reaches for unprompted, and naming it is exactly the availability cost *Prompt the positive* warns about |
| `SKILL.md:290` | *Recorded here so a future Caesar does not helpfully restore it* | Not a rule to follow but a note about why the section exists. The rule it guards — *only language Raj reads at full speed is eligible* — is stated positively and stands on its own |

## The 1–2 riskiest hunks

1. **`skill/SKILL.md:52`** — the grill-only pointer, now four words longer for a 16-line target
   file. This is the one pairing that flirts with the ticket's own step-5 caution: *a pairing
   that lengthens a pointer past the material it points at is the one to reconsider.* Kept
   because the added clause **is** a rung-3 stub — *the primary owns it* is the single fact a
   grill-only session must not act wrongly on if the link is never followed — but it is the
   hunk to cut first if the pointer budget is judged tighter than that.

2. **`skill/references/dispatch.md:38`** — the only heading rewritten rather than extended.
   Rules 1–3 of the skill block are a numbered set read in order, and rule 1's heading is now
   longer than rules 2 and 3, which flattens the parallelism the numbering leans on. The
   original negative is intact at the end of the heading, so nothing is lost, but the set reads
   slightly less like a set.

## Blast radius, and whether it is revertable

Prose only, in one skill, across five files. No script, no schema, no fixture, no `docs/`, no
frontmatter. Nothing executes, and nothing else in the repo reads these files programmatically.
The junction at `C:\Users\rajdh\.claude\skills\caesar` still points where it did; the main
checkout's `skill/` is untouched until this merges.

Fully revertable: `git revert` on the two commits restores `main`'s wording exactly. The worst
realistic failure is a pointer reading marginally heavier per turn — a cost, not a correctness
bug, and visible in the next dogfood rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
