### PR TITLE
feat(scripts): publish every discovered run directory to the private gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Then, from inside whichever repo owns the map:
 | `skill/scripts/spawn-ticket-agent.ps1` | Frozen: fire one headless ticket agent, worktree + deny list |
 | `skill/scripts/remove-worktree.ps1` | Frozen: fail-closed worktree teardown |
 | `skill/scripts/status.ps1` | The status view — renders over the sweep, no query of its own |
+| `skill/scripts/publish-runs.ps1` | Renders every discovered `.claude\caesar-runs\` directory into the private run-log gist, one file per repo |
 | `install.ps1` | The junction install |
 | `docs/research/` | Prior-art and measurement write-ups |
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -141,7 +141,9 @@ On a clean session that is about four lines.
    with a human, so you *are* the channel.
 4. **Harvest.** A landing **wakes you** — the watcher emits one line per event, and
    that line arrives even while you sit idle mid-grill. On each: verify against GitHub,
-   append the gist to the map, tear down the worktree.
+   append the gist to the map, tear down the worktree, then run
+   `scripts/publish-runs.ps1` so the run's final cost, turns and `GIST:` line reach
+   the phone-readable gist the same pass they reach the map.
 5. **Repeat** until the frontier is empty.
 
 One HITL ticket per session, worked through to a resolution — never resolve more than one

--- a/skill/references/dispatch.md
+++ b/skill/references/dispatch.md
@@ -10,6 +10,10 @@ Heavy, Execute, Tail — is defined here and used by [`failure.md`](failure.md).
 its own git worktree. The script carries the flag set and the deny list; fire every dispatch
 through it, and do not compose that command by hand.
 
+Right after the dispatch returns, run `scripts/publish-runs.ps1` — the new run's `RUNNING`
+row is what makes the gist worth reading from a phone mid-run, and the render is a pull
+over the run directories, not a push the spawn needed to make.
+
 **Composing a dispatch prompt** — the ordered shape it takes, and what the guardrail frame
 already carries. Read it before you write one; a prompt shaped from memory restates the frame
 and leaves the centurion with no bound of its own:

--- a/skill/scripts/publish-runs.ps1
+++ b/skill/scripts/publish-runs.ps1
@@ -1,0 +1,183 @@
+<#
+.SYNOPSIS
+  Render every Caesar run directory on this machine into the private gist, one
+  markdown file per repo (issue #160).
+
+.DESCRIPTION
+  Discovers every `<ProjectsRoot>\*\.claude\caesar-runs` directory - presence of the
+  directory is the only test, so a repo added later needs no edit here. Groups the
+  files in each by stem (`<name>-<yyyyMMdd>-<HHmmss>`), classifies each stem RUNNING /
+  LANDED / LANDED (no GIST) / ERRORED from its result JSON (mirrors watch-runs.ps1's
+  classifier), and writes one `<repo>.md` per directory to the gist whose id is read
+  from `caesar\.claude\caesar-runs\.gist-id` (falls back to the known id if that file
+  is missing).
+
+  Every timestamp in the render comes from the run data itself, never the clock, so
+  two consecutive runs over unchanged directories produce byte-identical gist content
+  (#160's idempotence requirement - a clock-derived "Updated" header cannot pass it).
+
+.EXAMPLE
+  .\publish-runs.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$ProjectsRoot = (Join-Path $env:USERPROFILE 'Projects'),
+    [string]$GistId,
+    [int]$Cap = 40
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $GistId) {
+    $idFile = Join-Path $ProjectsRoot 'caesar\.claude\caesar-runs\.gist-id'
+    $GistId = if (Test-Path -LiteralPath $idFile) { ([IO.File]::ReadAllText($idFile)).Trim() }
+              else { '12fdf235c41ddc3f74a4847bdb89dc8c' }
+}
+
+function Get-StderrTail([string]$ErrFile) {
+    if (-not $ErrFile -or -not (Test-Path -LiteralPath $ErrFile)) { return 'stderr empty' }
+    $last = @(Get-Content -LiteralPath $ErrFile -Tail 40 -ErrorAction SilentlyContinue) |
+        Where-Object { $_.Trim() } | Select-Object -Last 1
+    if (-not $last) { return 'stderr empty' }
+    $tail = 'stderr: ' + ($last.Trim() -replace '\s+', ' ')
+    if ($tail.Length -gt 200) { $tail = $tail.Substring(0, 200) + '...' }
+    $tail
+}
+
+function Get-IssueLink([string]$PromptFile) {
+    if (-not $PromptFile -or -not (Test-Path -LiteralPath $PromptFile)) { return $null }
+    # A prompt file for a run still in flight is open for write by the centurion
+    # process (redirected stdin) - share Read/Write so a live run does not blow up
+    # the whole render, and skip the link rather than fail the pass.
+    try {
+        $stream = [IO.File]::Open($PromptFile, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::ReadWrite)
+        try {
+            $reader = New-Object IO.StreamReader($stream)
+            $text = $reader.ReadToEnd()
+        } finally { $stream.Dispose() }
+    } catch { return $null }
+    $m = [regex]::Match($text, 'https://github\.com/[^/\s]+/[^/\s]+/issues/(\d+)')
+    if (-not $m.Success) { return $null }
+    "[#$($m.Groups[1].Value)]($($m.Value))"
+}
+
+# One run block, as a list of content lines - blocks join on "`n", the render joins
+# blocks on "`n`n" so each pair ends up separated by exactly one blank line, matching
+# the hand-written gist's shape.
+function Format-Run($RunDir, $Stem) {
+    $name = $Stem -replace '-\d{8}-\d{6}$', ''
+    $tsMatch = [regex]::Match($Stem, '(\d{8})-(\d{6})$')
+    $ts = [datetime]::ParseExact($tsMatch.Value, 'yyyyMMdd-HHmmss', $null)
+    $when = $ts.ToString('ddd dd MMM HH:mm')
+
+    $jsonFile = Join-Path $RunDir "$Stem.json"
+    $dispatchFile = Join-Path $RunDir "$Stem.dispatch.json"
+    $promptFile = Join-Path $RunDir "$Stem.prompt.txt"
+    $errFile = Join-Path $RunDir "$Stem.err"
+
+    $tierModel = $null
+    if (Test-Path -LiteralPath $dispatchFile) {
+        try {
+            $d = [IO.File]::ReadAllText($dispatchFile) | ConvertFrom-Json
+            if ($d.Tier -and $d.Model) { $tierModel = "$($d.Tier)/$($d.Model)" }
+        } catch { }
+    }
+    $link = Get-IssueLink $promptFile
+
+    $info = Get-Item -LiteralPath $jsonFile
+    if ($info.Length -eq 0) {
+        $status = "$when - RUNNING"
+        if ($tierModel) { $status += " - $tierModel" }
+        $lines = @("### $name", $status)
+        if ($link) { $lines += $link }
+        return ,$lines
+    }
+
+    $r = [IO.File]::ReadAllText($jsonFile) | ConvertFrom-Json
+    $cost = '{0:0.00}' -f $r.total_cost_usd
+    $costTurns = "`$$cost - $($r.num_turns) turns"
+
+    if ($r.is_error) {
+        $status = "$when - ERRORED - $costTurns"
+        if ($tierModel) { $status += " - $tierModel" }
+        $lines = @("### $name", $status, '',
+            "terminal_reason ``$($r.terminal_reason)``",
+            "``$(Get-StderrTail $errFile)``")
+        return ,$lines
+    }
+
+    $gistLine = @($r.result -split "`r?`n") | Where-Object { $_ -match '^\s*GIST:\s' } | Select-Object -First 1
+    if ($gistLine) {
+        $status = "$when - LANDED - $costTurns"
+        if ($tierModel) { $status += " - $tierModel" }
+        $lines = @("### $name", $status)
+        if ($link) { $lines += $link }
+        $lines += @('', $gistLine.Trim())
+        return ,$lines
+    }
+
+    $status = "$when - LANDED (no GIST) - $costTurns"
+    if ($tierModel) { $status += " - $tierModel" }
+    $lines = @("### $name", $status)
+    if ($link) { $lines += $link }
+    $lines += @('', 'exit clean but printed no GIST line')
+    ,$lines
+}
+
+function Format-Repo($RepoName, $RunDir) {
+    $stems = @(Get-ChildItem -LiteralPath $RunDir -Filter '*.json' -File |
+        Where-Object { $_.Name -notlike '*.dispatch.json' } |
+        ForEach-Object { $_.BaseName } |
+        Sort-Object { [regex]::Match($_, '(\d{8}-\d{6})$').Value } -Descending |
+        Select-Object -First $Cap)
+
+    $blocks = @($stems | ForEach-Object { ,(Format-Run $RunDir $_) })
+    $newestTs = [regex]::Match($stems[0], '(\d{8})-(\d{6})$')
+    $updated = [datetime]::ParseExact($newestTs.Value, 'yyyyMMdd-HHmmss', $null).ToString('ddd dd MMM yyyy HH:mm')
+
+    $header = @("# $RepoName runs", '', "Updated $updated - newest first, last $Cap.")
+    $body = ($blocks | ForEach-Object { $_ -join "`n" }) -join "`n`n"
+    ($header -join "`n") + "`n`n" + $body + "`n"
+}
+
+$repoDirs = Get-ChildItem -LiteralPath $ProjectsRoot -Directory -ErrorAction SilentlyContinue |
+    ForEach-Object {
+        $runDir = Join-Path $_.FullName '.claude\caesar-runs'
+        if (Test-Path -LiteralPath $runDir -PathType Container) {
+            [pscustomobject]@{ Name = $_.Name; RunDir = $runDir }
+        }
+    }
+
+if (-not $repoDirs) { throw "No .claude\caesar-runs directory found under $ProjectsRoot" }
+
+$tmp = Join-Path ([IO.Path]::GetTempPath()) "caesar-publish-runs-$(Get-Random)"
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+
+$desired = @{}
+foreach ($repo in $repoDirs) {
+    $fileName = "$($repo.Name).md"
+    $content = Format-Repo $repo.Name $repo.RunDir
+    $path = Join-Path $tmp $fileName
+    [IO.File]::WriteAllText($path, $content, (New-Object System.Text.UTF8Encoding $false))
+    $desired[$fileName] = $path
+}
+
+$existing = @(gh api "gists/$GistId" --jq '.files | keys[]')
+
+foreach ($fileName in $desired.Keys) {
+    if ($existing -contains $fileName) {
+        gh gist edit $GistId --filename $fileName $desired[$fileName] | Out-Null
+    } else {
+        gh gist edit $GistId --add $desired[$fileName] | Out-Null
+    }
+}
+
+# The hand-written gist's one file was `caesar-runs.md`; the caesar repo now renders
+# as `caesar.md` like every other repo, so the old name is retired once its content
+# has a home under the new one.
+if (($existing -contains 'caesar-runs.md') -and -not $desired.ContainsKey('caesar-runs.md')) {
+    gh gist edit $GistId --remove 'caesar-runs.md' | Out-Null
+}
+
+Remove-Item -Recurse -Force -LiteralPath $tmp -ErrorAction SilentlyContinue
+Write-Output "Published $($desired.Keys.Count) file(s) to gist $GistId"


### PR DESCRIPTION
## What changed

- New `skill/scripts/publish-runs.ps1`: discovers every `C:\Users\rajdh\Projects\*\.claude\caesar-runs` directory (presence of the directory is the whole test, no hardcoded repo list), groups files by stem, classifies each run RUNNING / LANDED / LANDED (no GIST) / ERRORED from its result JSON (mirrors `watch-runs.ps1`'s classifier), and writes one `<repo>.md` per repo to the existing private gist `12fdf235c41ddc3f74a4847bdb89dc8c`. All timestamps are derived from the run data itself, never the clock.
- `skill/SKILL.md` step 4 of `## The loop` (Harvest) now calls it after tearing down the worktree.
- `skill/references/dispatch.md` calls it right after a dispatch returns.
- `README.md`'s layout table lists the script.
- The old hand-written `caesar-runs.md` file is retired in favour of `caesar.md`, matching the naming used for the other seven repos.

## Why

Ticket [#160](https://github.com/Dhillvn/Caesar/issues/160): the gist existed but nothing wrote it, and it covered only `caesar`'s own runs. Raj reads run state from his phone; this makes all eight discovered repos' run corpora reach the one place he reads from.

## Proof it ran

**Idempotence** — ran the script twice, captured all 8 rendered files from the gist after each run, diffed:

```
diff .scratch/run1-caesar.md .scratch/run2-caesar.md
diff .scratch/run1-dan-claude-course.md .scratch/run2-dan-claude-course.md
diff .scratch/run1-numen-crm.md .scratch/run2-numen-crm.md
diff .scratch/run1-numen-edit-smoke.md .scratch/run2-numen-edit-smoke.md
diff .scratch/run1-numen-ops.md .scratch/run2-numen-ops.md
diff .scratch/run1-numen-platform.md .scratch/run2-numen-platform.md
diff .scratch/run1-numen-site.md .scratch/run2-numen-site.md
diff .scratch/run1-numen-vsl.md .scratch/run2-numen-vsl.md
ALL DIFFS EXIT: 0
```
All 8 files byte-identical across consecutive runs.

**Privacy**:
```
$ gh api gists/12fdf235c41ddc3f74a4847bdb89dc8c --jq .public
false
```

**File coverage** — `gh gist view 12fdf235c41ddc3f74a4847bdb89dc8c --files` lists exactly 8 files: `caesar.md`, `dan-claude-course.md`, `numen-crm.md`, `numen-edit-smoke.md`, `numen-ops.md`, `numen-platform.md`, `numen-site.md`, `numen-vsl.md`.

## Riskiest hunks

- `skill/scripts/publish-runs.ps1:186-193` — the `gh gist edit` add-vs-update branch and the `caesar-runs.md` → `caesar.md` rename/removal. If the existing-filename lookup (`gh api gists/$GistId --jq '.files | keys[]'`) ever returns stale or empty data, this could try to `--add` a file that already exists (gh errors, non-destructive) or skip the `--remove` of the old name (harmless, just leaves a stale file behind).
- `skill/scripts/publish-runs.ps1:98-99` — `Get-Item -LiteralPath $jsonFile` / 0-byte check is the sole signal for "still running." A result file that is briefly 0 bytes for a reason other than an in-flight run (e.g. a future harness changing how it writes the file) would misrender as RUNNING rather than erroring loudly.

## Blast radius

Read-only against every repo's `.claude\caesar-runs\` (only reads run files, writes nothing there) and writes only to the pre-existing private gist's markdown files. Fully revertable: `git revert` this commit, and the gist can be manually reset from `.scratch/caesar-runs.original.md` in the ticket-160 worktree (the pre-change hand-written content, saved before this ran) if ever needed. No other repo, branch, or `main` is touched.
