### PR TITLE
fix(skill): resolve Wayfinder through the plugin's category directories

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -20,13 +20,18 @@ the Skill tool refuses it — ask the harness where its plugin is installed inst
 
 ```powershell
 claude plugin list --json | ConvertFrom-Json |
-  ForEach-Object { Join-Path $_.installPath 'skills\wayfinder\SKILL.md' } |
-  Where-Object { Test-Path $_ }
+  ForEach-Object { Get-ChildItem (Join-Path $_.installPath 'skills') -Recurse -Filter SKILL.md -ErrorAction SilentlyContinue } |
+  Where-Object { $_.Directory.Name -eq 'wayfinder' } |
+  ForEach-Object { $_.FullName }
 ```
+
+The recursion is deliberate and must not be flattened back to a fixed depth: the plugin
+groups its skills under category directories — Wayfinder sits in `engineering\`, beside
+`productivity\`, `misc\` and `in-progress\` — and upstream may recategorise it again.
 
 `installPath` is the version the harness is actually using — **run that query each session and
 read Wayfinder from the path it returns.** Never write a literal path to
-Wayfinder and never glob the plugin cache: cache paths carry a version segment and old
+Wayfinder and never search the cache from its root: cache paths carry a version segment and old
 version directories are never removed, so a literal either breaks on the next upstream
 release or — worse, and silently — keeps resolving to a frozen copy while you believe you
 are reading current Wayfinder. If the command returns nothing, Wayfinder is not installed;


### PR DESCRIPTION
## What changed

`skill/SKILL.md`'s Wayfinder resolution query now searches recursively under `<installPath>\skills` and matches on the containing directory name, instead of joining a fixed `skills\wayfinder\SKILL.md`.

One neighbouring clause changed with it: *"never glob the plugin cache"* became *"never search the cache from its root"*. The new query searches inside a CLI-reported `installPath`, which the old wording appeared to forbid — but the reasoning that follows is about stale version directories, and that risk comes from searching the **cache root**, not from searching within the resolved install. Narrowing the prohibition keeps the guard and removes the contradiction.

Three lines of prose added stating the recursion is deliberate, so a later pass does not "simplify" it back to a fixed depth.

## Why

Closes #169.

The mattpocock plugin groups its skills under category directories — Wayfinder is at `skills\engineering\wayfinder\SKILL.md`, beside `productivity\`, `misc\` and `in-progress\`. The old query was one directory short and returned nothing.

That is not a quiet failure. `SKILL.md` tells the session:

> If the command returns nothing, Wayfinder is not installed; say so rather than guessing at a path.

So a session concludes Wayfinder is absent when it is present and enabled, and then drives or charts a map **without ever reading the format it is driving**.

**Observed twice.** #169 records it on 2026-08-15 charting #163, where the session fell back to an archived hand-copy that happened to be current. It recurred on 2026-08-16 charting #178 — this session hit it, reported Wayfinder not installed, and only recovered because Raj said otherwise. Two occurrences, two different maps, same silent failure.

## Proof it ran

Dogfooded on this machine against the live plugin set. The block was **extracted from the committed file and executed verbatim**, not retyped:

Old query — the defect:

```
count=0
```

New query, as written in `skill/SKILL.md`:

```
count=1
C:\Users\rajdh\.claude\plugins\cache\mattpocock\mattpocock-skills\1.2.2\skills\engineering\wayfinder\SKILL.md  ->  exists=True
```

#169's acceptance is *"returns exactly one path and that path exists"*. Met.

Run across all 13 installed plugins, several of which have no `skills` directory — suppressed by `-ErrorAction SilentlyContinue`, no errors surfaced.

## Riskiest hunks

- **`skill/SKILL.md:22-25`** — the query. It assumes exactly one plugin ships a skill directory named `wayfinder`. Today that holds (count=1). If a second ever did, the session gets two paths and the surrounding prose does not say which wins. Not handled here: disambiguation logic for a collision that does not exist is speculative, and the failure would be loud (two paths printed) rather than silent, which is the opposite of the bug being fixed.
- **`skill/SKILL.md:29`** — the narrowed prohibition. This *weakens* a standing rule. The wording was chosen so the guard still forbids the dangerous act (searching from the cache root, which can resolve to a frozen old version directory) while permitting the safe one. If it reads as permission to search the cache broadly, that is a regression risk on a rule that exists for a real reason.

## Blast radius

One file, 8 insertions, 3 deletions, documentation only — no script and no frozen artifact is touched.

The changed lines sit in `SKILL.md`'s always-loaded body, so **every** Caesar session reads them. That is the point: the bug is in the path every session walks.

Note `~\.claude\skills\caesar` is a junction to `C:\Users\rajdh\Projects\caesar\skill`, so merging this changes the live skill immediately, with no install step.

**Revertable:** yes, a single-commit revert of a documentation change with no dependants.
