### PR TITLE
feat(skill): dashboard-data.ps1 - the whole Caesar picture as JSON

### DIFF
--- a/skill/scripts/dashboard-data.ps1
+++ b/skill/scripts/dashboard-data.ps1
@@ -1,0 +1,148 @@
+<#
+.SYNOPSIS
+  Whole Caesar picture - every driven map, its tickets, open PRs, agent slots and
+  centurion runs - as one JSON document on stdout (issue #181).
+
+.DESCRIPTION
+  Renders over frontier.ps1 for the per-map ticket sweep and over ticket-state.ps1
+  (issue #24's owner/state/rank rules, including the flagged-owner rule from #17) for
+  the open-ticket view, so those rules stay in exactly one place shared with
+  status.ps1.
+
+  Duplicates publish-runs.ps1's run classifier rather than sharing it: that script's
+  job is rendering markdown into a gist, not returning data, and its classifier is a
+  few lines wedged inside a markdown formatter, not a seam worth carving out for this.
+  A second small copy of the RUNNING / LANDED / LANDED (no GIST) / ERRORED rule now
+  exists - see the PR body.
+
+  A map that errors mid-sweep (bad URL, gh failure) records the error against that map
+  and the sweep continues - one bad map cannot take the whole document down.
+
+.EXAMPLE
+  .\dashboard-data.ps1
+  .\dashboard-data.ps1 -MapUrl https://github.com/Dhillvn/caesar/issues/1
+#>
+[CmdletBinding()]
+param(
+    [string[]]$MapUrl,
+    [int]$Cap = 4,
+    [string]$ProjectsRoot = (Join-Path $env:USERPROFILE 'Projects')
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'ticket-state.ps1')
+$sweepScript = Join-Path $PSScriptRoot 'frontier.ps1'
+
+if (-not $MapUrl) {
+    $found = gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving --json url
+    if ($LASTEXITCODE -ne 0) { throw "gh search issues failed" }
+    $MapUrl = @(($found | ConvertFrom-Json) | ForEach-Object { $_.url })
+}
+
+$maps = foreach ($url in $MapUrl) {
+    $repo = $null
+    $mapNum = $null
+    try {
+        if ($url -notmatch '^https?://github\.com/([^/]+)/([^/]+)/issues/(\d+)') {
+            throw "Not a GitHub issue URL: $url"
+        }
+        $repo = "$($Matches[1])/$($Matches[2])"
+        $mapNum = [int]$Matches[3]
+
+        $rows = @(& $sweepScript -MapUrl $url)
+        $done = @($rows | Where-Object { $_.Status -eq 'closed' } | Sort-Object ClosedAt)
+        $open = @(Get-OpenTickets $rows | ForEach-Object {
+            [pscustomobject]@{
+                Number = $_.Number; Title = $_.Title; Url = $_.Url; Type = $_.Type
+                Who = $_.Who; State = $_.State
+                BlockedBy = @(if ($_.BlockedBy) { $_.BlockedBy -split ',' | ForEach-Object { [int]$_ } } else { @() })
+            }
+        })
+        $lastDecided = if ($done.Count -gt 0) {
+            [pscustomobject]@{ Number = $done[-1].Number; Title = $done[-1].Title; Url = $done[-1].Url }
+        } else { $null }
+
+        [pscustomobject]@{
+            Number = $mapNum; Title = $rows[0].MapTitle; Repo = $repo; Url = $url
+            DoneCount = $done.Count; OpenCount = $open.Count
+            LastDecided = $lastDecided; OpenTickets = $open; Error = $null
+        }
+    } catch {
+        [pscustomobject]@{
+            Number = $mapNum; Title = $null; Repo = $repo; Url = $url
+            DoneCount = 0; OpenCount = 0; LastDecided = $null; OpenTickets = @()
+            Error = $_.Exception.Message
+        }
+    }
+}
+$maps = @($maps)
+
+$slots = @($maps | ForEach-Object { $_.OpenTickets } | Where-Object { $_.Who -eq 'Caesar' -and $_.State -eq 'Ongoing' }).Count
+
+$repos = @($maps | Where-Object { $_.Repo } | ForEach-Object { $_.Repo } | Select-Object -Unique)
+$prs = foreach ($r in $repos) {
+    $json = gh pr list --repo $r --state open --json number,title,url,isDraft
+    if ($LASTEXITCODE -ne 0) { throw "gh pr list failed for $r" }
+    foreach ($pr in ($json | ConvertFrom-Json)) {
+        [pscustomobject]@{ Number = $pr.number; Title = $pr.title; Url = $pr.url; Repo = $r; Draft = $pr.isDraft }
+    }
+}
+$prs = @($prs)
+
+# ponytail: small duplicate of publish-runs.ps1's classifier - see .DESCRIPTION.
+function Get-RunClassification($JsonFile) {
+    $info = Get-Item -LiteralPath $JsonFile
+    if ($info.Length -eq 0) { return @{ Classification = 'RUNNING'; Result = $null } }
+    $r = [IO.File]::ReadAllText($JsonFile) | ConvertFrom-Json
+    if ($r.is_error) { return @{ Classification = 'ERRORED'; Result = $r } }
+    $gistLine = @($r.result -split "`r?`n") | Where-Object { $_ -match '^\s*GIST:\s' } | Select-Object -First 1
+    if ($gistLine) { return @{ Classification = 'LANDED'; Result = $r } }
+    return @{ Classification = 'LANDED (no GIST)'; Result = $r }
+}
+
+function Get-RunTicket([string]$PromptFile) {
+    if (-not $PromptFile -or -not (Test-Path -LiteralPath $PromptFile)) { return $null }
+    try {
+        $stream = [IO.File]::Open($PromptFile, [IO.FileMode]::Open, [IO.FileAccess]::Read, [IO.FileShare]::ReadWrite)
+        try {
+            $reader = New-Object IO.StreamReader($stream)
+            $text = $reader.ReadToEnd()
+        } finally { $stream.Dispose() }
+    } catch { return $null }
+    $m = [regex]::Match($text, 'https://github\.com/[^/\s]+/[^/\s]+/issues/(\d+)')
+    if ($m.Success) { [int]$m.Groups[1].Value } else { $null }
+}
+
+$runs = foreach ($repoDir in (Get-ChildItem -LiteralPath $ProjectsRoot -Directory -ErrorAction SilentlyContinue)) {
+    $runDir = Join-Path $repoDir.FullName '.claude\caesar-runs'
+    if (-not (Test-Path -LiteralPath $runDir -PathType Container)) { continue }
+    $stems = @(Get-ChildItem -LiteralPath $runDir -Filter '*.json' -File |
+        Where-Object { $_.Name -notlike '*.dispatch.json' } |
+        ForEach-Object { $_.BaseName })
+    foreach ($stem in $stems) {
+        $jsonFile = Join-Path $runDir "$stem.json"
+        $promptFile = Join-Path $runDir "$stem.prompt.txt"
+        $tsMatch = [regex]::Match($stem, '(\d{8})-(\d{6})$')
+        $ts = if ($tsMatch.Success) { [datetime]::ParseExact($tsMatch.Value, 'yyyyMMdd-HHmmss', $null).ToString('o') } else { $null }
+        $class = Get-RunClassification $jsonFile
+        [pscustomobject]@{
+            Name = $stem -replace '-\d{8}-\d{6}$', ''
+            Repo = $repoDir.Name
+            Classification = $class.Classification
+            Ticket = Get-RunTicket $promptFile
+            Cost = $class.Result.total_cost_usd
+            Turns = $class.Result.num_turns
+            Timestamp = $ts
+        }
+    }
+}
+$runs = @($runs)
+
+[pscustomobject]@{
+    GeneratedAt = (Get-Date).ToString('o')
+    Maps = $maps
+    OpenPrs = $prs
+    AgentSlots = [pscustomobject]@{ InUse = $slots; Cap = $Cap }
+    CenturionRuns = $runs
+} | ConvertTo-Json -Depth 10

--- a/skill/scripts/status.ps1
+++ b/skill/scripts/status.ps1
@@ -36,26 +36,7 @@ function Format-Bar([char]$L, [char]$M, [char]$R) {
     [string]$L + ($segments -join [string]$M) + [string]$R
 }
 
-# Wayfinder: research is always Caesar's, grilling and prototype always Raj's, and a
-# task is Caesar's unless he stamps `caesar:hitl` on it ("the agent drives it alone
-# where it can"). Anything unlabelled is Raj's — an unowned ticket should surface.
-function Get-Who($Row) {
-    if ($Row.Type -eq 'research') { return 'Caesar' }
-    if ($Row.Type -eq 'task' -and -not $Row.Hitl) { return 'Caesar' }
-    'You'
-}
-
-# what needs you, then what is moving, then what is next, then what is stuck
-function Get-Rank($Who, $State) {
-    switch ("$Who/$State") {
-        'You/Needs you'  { -1 }
-        'You/Queued'     { 0 }
-        'You/Ongoing'    { 1 }
-        'Caesar/Ongoing' { 2 }
-        'Caesar/Queued'  { 3 }
-        default          { 4 }
-    }
-}
+. (Join-Path $PSScriptRoot 'ticket-state.ps1')
 
 function Split-Wrap([string]$Text, [int]$Width) {
     $lines = @()
@@ -83,17 +64,7 @@ foreach ($url in $MapUrl) {
 
     $rows = @(& $sweepScript -MapUrl $url)
     $done = @($rows | Where-Object { $_.Status -eq 'closed' } | Sort-Object ClosedAt)
-    $open = @($rows | Where-Object { $_.Status -ne 'closed' } | ForEach-Object {
-        $state = switch ($_.Status) { 'blocked' { 'Blocked' } 'flagged' { 'Needs you' } 'claimed' { 'Ongoing' } default { 'Queued' } }
-        # A flagged ticket (#17) is back on Raj whatever its type says, and must not
-        # read as Queued - Queued means takeable. It also stops counting as an agent slot.
-        $who = if ($_.Status -eq 'flagged') { 'You' } else { Get-Who $_ }
-        [pscustomobject]@{
-            Number = $_.Number; Title = $_.Title; Type = $_.Type
-            Who = $who; State = $state; BlockedBy = $_.BlockedBy
-            Rank = (Get-Rank $who $state)
-        }
-    } | Sort-Object Rank, Number)
+    $open = Get-OpenTickets $rows
 
     $slots += @($open | Where-Object { $_.Who -eq 'Caesar' -and $_.State -eq 'Ongoing' }).Count
 

--- a/skill/scripts/ticket-state.ps1
+++ b/skill/scripts/ticket-state.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+  Shared open-ticket ownership/state rules (issue #24, #17), used by status.ps1 and
+  dashboard-data.ps1 so the flagged-owner rule lives in exactly one place.
+#>
+
+# Wayfinder: research is always Caesar's, grilling and prototype always Raj's, and a
+# task is Caesar's unless he stamps `caesar:hitl` on it ("the agent drives it alone
+# where it can"). Anything unlabelled is Raj's - an unowned ticket should surface.
+function Get-Who($Row) {
+    if ($Row.Type -eq 'research') { return 'Caesar' }
+    if ($Row.Type -eq 'task' -and -not $Row.Hitl) { return 'Caesar' }
+    'You'
+}
+
+# what needs you, then what is moving, then what is next, then what is stuck
+function Get-Rank($Who, $State) {
+    switch ("$Who/$State") {
+        'You/Needs you'  { -1 }
+        'You/Queued'     { 0 }
+        'You/Ongoing'    { 1 }
+        'Caesar/Ongoing' { 2 }
+        'Caesar/Queued'  { 3 }
+        default          { 4 }
+    }
+}
+
+# Turns frontier.ps1's rows for one map into the open-ticket view: who owns it, what
+# state it reads as, and its rank. A flagged ticket (#17) is back on Raj whatever its
+# type says, reads Needs you, and does not count as an agent slot.
+function Get-OpenTickets($Rows) {
+    @($Rows | Where-Object { $_.Status -ne 'closed' } | ForEach-Object {
+        $state = switch ($_.Status) { 'blocked' { 'Blocked' } 'flagged' { 'Needs you' } 'claimed' { 'Ongoing' } default { 'Queued' } }
+        $who = if ($_.Status -eq 'flagged') { 'You' } else { Get-Who $_ }
+        [pscustomobject]@{
+            Number = $_.Number; Title = $_.Title; Type = $_.Type; Url = $_.Url
+            Who = $who; State = $state; BlockedBy = $_.BlockedBy
+            Rank = (Get-Rank $who $state)
+        }
+    } | Sort-Object Rank, Number)
+}


### PR DESCRIPTION
## What changed

Adds `skill\scripts\dashboard-data.ps1`. It calls `frontier.ps1` (frozen, untouched) per driven map, computes owner/state/rank with a new shared helper `skill\scripts\ticket-state.ps1`, and emits one JSON document to stdout: per map (number, title, repo, url, done/open counts, last decided ticket, every open ticket with number/title/url/type/owner/state/open blockers), plus globally every open PR, agent slots in use vs cap, every centurion run (classification/repo/ticket/cost/turns/timestamp), and a generated-at timestamp.

`status.ps1`'s owner/state/rank logic (the flagged-ticket-is-always-Raj's rule, issue #17) is now shared, not copied: it moved into `skill\scripts\ticket-state.ps1` as `Get-Who` / `Get-Rank` / `Get-OpenTickets`, and `status.ps1` dot-sources it. `status.ps1`'s own CLI output and `-MapUrl`/`-Cap` params are unchanged (verified below).

publish-runs.ps1's RUNNING/LANDED/LANDED (no GIST)/ERRORED classifier is **duplicated**, not shared — its classifier is a few lines wedged inside a function whose real job is formatting markdown for a gist, and carving a data-only seam out of it wasn't worth the coupling for four `if`/`else` lines. A second small copy of that rule now exists, in `dashboard-data.ps1`'s `Get-RunClassification`.

`frontier.ps1` is untouched (byte-identical, confirmed via `git status`/`git diff --stat`).

## Why

https://github.com/Dhillvn/Caesar/issues/181 - Caesar needs one data seam that has the whole picture (every driven map, its tickets, open PRs, agent slots, centurion runs) so a later renderer (issue #178's map) doesn't have to re-derive ownership/state rules or re-scan run directories itself.

## Proof it ran

Live map set at run time: **6 maps** (`gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving` returned #178, #6, #220, #164, #35, #17 - the ticket warned this could be 9 or 4 while a parallel centurion on #180 strips `caesar:driving`; it was 6 this run).

`status.ps1` over those 6 maps (open counts per map: 5, 6, 2, 3, 0, 7 = **23 open**, **0 open PRs**, **2 of 4 agent slots**):

```
CAESAR - 2026-08-16 10:24

MAP #178  One self-refreshing command centre for every Caesar map
1 decided · 5 open · last was #180 Retire caesar:driving from the maps that are finished
...
MAP #6  ... 10 decided · 6 open ...
MAP #220 ... 20 decided · 2 open ...
MAP #164 ... 14 decided · 3 open ...
MAP #35  ... 17 decided · 0 open ... nothing open - map is done
MAP #17  ... 27 decided · 7 open ...

Agent slots: 2 of 4 in use
Waiting on your word:
  nothing - no open PRs
```

`dashboard-data.ps1` over the same 6 maps plus one deliberately bad map URL (`.../numen-ops/issues/999999`) - the bad map errors, everything else survives:

```json
{
  "GeneratedAt": "2026-08-16T10:24:50+01:00",
  "Maps": [
    { "Number": 178, "Repo": "Dhillvn/Caesar", "DoneCount": 1, "OpenCount": 5, "Error": null, "OpenTickets": [ /* 5 tickets: #182 You/Ongoing, #179 Caesar/Ongoing, #181 Caesar/Ongoing, #183 Caesar/Blocked[182,181,179], #184 Caesar/Blocked[183] */ ] },
    { "Number": 6,   "Repo": "Dhillvn/numen-site", "DoneCount": 10, "OpenCount": 6, "Error": null, "OpenTickets": [ /* #12 Queued, #26 Ongoing, #13 Blocked[12], #20 Blocked[26,12], #21 Blocked[20], #22 Blocked[21] */ ] },
    { "Number": 220, "Repo": "Dhillvn/numen-ops", "DoneCount": 20, "OpenCount": 2, "Error": null, "OpenTickets": [ /* #242 Queued, #253 Ongoing */ ] },
    { "Number": 164, "Repo": "Dhillvn/numen-ops", "DoneCount": 14, "OpenCount": 3, "Error": null, "OpenTickets": [ /* #175 Queued, #182 Queued, #177 Ongoing */ ] },
    { "Number": 35,  "Repo": "Dhillvn/numen-ops", "DoneCount": 17, "OpenCount": 0, "Error": null, "OpenTickets": [] },
    { "Number": 17,  "Repo": "Dhillvn/numen-ops", "DoneCount": 27, "OpenCount": 7, "Error": null, "OpenTickets": [ /* #22, #203 Queued; #43 Ongoing; #23, #27, #29 Blocked[22]; #30 Blocked[203] */ ] },
    { "Number": 999999, "Repo": "Dhillvn/numen-ops", "DoneCount": 0, "OpenCount": 0,
      "Error": "gh api graphql failed for https://github.com/Dhillvn/numen-ops/issues/999999",
      "OpenTickets": [] }
  ],
  "OpenPrs": [],
  "AgentSlots": { "InUse": 2, "Cap": 4 },
  "CenturionRuns": [
    { "Name": "probe72-nowt", "Repo": "caesar", "Classification": "LANDED", "Ticket": 999999, "Cost": 0.1296, "Turns": 1, "Timestamp": "2026-08-05T13:11:48" },
    { "Name": "ticket-113-7431", "Repo": "caesar", "Classification": "ERRORED", "Ticket": 113, "Cost": 5.00, "Turns": 56, "Timestamp": "2026-08-07T08:15:45" },
    { "Name": "ticket-179-6850", "Repo": "caesar", "Classification": "RUNNING", "Ticket": 179, "Cost": null, "Turns": null, "Timestamp": "2026-08-16T10:18:55" }
    /* ...201 more, 204 runs total across caesar, dan-claude-course, numen-crm, numen-edit-smoke, numen-ops */
  ]
}
```

Sum of `Maps[].OpenCount` = 5+6+2+3+0+7 = **23**, matches `status.ps1`'s 23 open. `OpenPrs.Count` = 0, matches "nothing - no open PRs". `AgentSlots` = 2/4, matches "Agent slots: 2 of 4 in use". The bad map (#999999) carries its `gh` error in `Error` and every other map is fully populated - the whole run still exits 0 and the JSON round-trips through `ConvertFrom-Json` with `BlockedBy` intact as a real array (checked directly, e.g. map #178 ticket #183 → `BlockedBy: [182, 181, 179]`), which is the thing `-Depth 2` would have silently mangled.

## Riskiest hunks

- `dashboard-data.ps1:44-51` - the map-loop `try`/`catch`. Getting this wrong (e.g. throwing before `$repo`/`$mapNum` are captured, or catching too narrowly) is exactly the "one bad map takes the whole document down" failure the ticket calls out; proven above with issue #999999.
- `skill\scripts\status.ps1` diff (the `Get-Who`/`Get-Rank`/inline open-ticket block replaced by `. ticket-state.ps1` + `Get-OpenTickets $rows`) - `status.ps1` runs at the start of every Caesar session, so a behavior drift here is silent until someone reads a wrong owner/state. Proven above: full 6-map `status.ps1` output is unchanged in shape and numbers from before this change.

## Blast radius / revertability

Additive only outside `status.ps1`: new files `dashboard-data.ps1` and `ticket-state.ps1`, nothing else calls either yet. `status.ps1`'s CLI contract (params, output format) is unchanged - only its internals now come from a shared file. `frontier.ps1` untouched. Fully revertable with `git revert`; no state, no external side effects (read-only `gh` calls only).

Closes #181.
