### PR TITLE
feat(skill): one command opens the command centre (#184)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -20,10 +20,24 @@
 [CmdletBinding()]
 param(
     [string]$LinkPath = (Join-Path $env:USERPROFILE '.claude\skills\caesar'),
+    # %LOCALAPPDATA%\Microsoft\WindowsApps is on the user PATH by default on Windows 11
+    # and needs no elevation to write, so a .cmd dropped here is a command from any
+    # directory with no PATH edit and no profile edit (issue #184).
+    [string]$ShimPath = (Join-Path $env:LOCALAPPDATA 'Microsoft\WindowsApps\caesar-centre.cmd'),
     [switch]$Uninstall
 )
 
 $ErrorActionPreference = 'Stop'
+
+function Set-CentreShim {
+    # The shim points at the junction, not at this repo checkout, so it keeps working
+    # when the repo moves. WriteAllText, not Set-Content: the repo's PowerShell rule.
+    $target = Join-Path $LinkPath 'scripts\command-centre.ps1'
+    $body = "@echo off`r`npowershell.exe -NoProfile -ExecutionPolicy Bypass -File `"$target`" %*`r`n"
+    [IO.File]::WriteAllText($ShimPath, $body)
+    Write-Host "Installed: $ShimPath -> $target"
+    Write-Host "Run 'caesar-centre' from any directory to open the command centre; 'caesar-centre stop' to stop it."
+}
 
 $source = Join-Path $PSScriptRoot 'skill'
 if (-not $Uninstall -and -not (Test-Path (Join-Path $source 'SKILL.md'))) {
@@ -34,6 +48,10 @@ $existing = Get-Item -LiteralPath $LinkPath -Force -ErrorAction SilentlyContinue
 $isJunction = $existing -and $existing.LinkType -eq 'Junction'
 
 if ($Uninstall) {
+    if (Test-Path -LiteralPath $ShimPath) {
+        Remove-Item -LiteralPath $ShimPath -Force
+        Write-Host "Uninstalled: removed shim $ShimPath"
+    }
     if (-not $existing) { Write-Host "Not installed: $LinkPath"; return }
     if (-not $isJunction) { throw "REFUSED: $LinkPath is a real directory, not our junction. Delete it yourself if you mean to." }
     [System.IO.Directory]::Delete($LinkPath)
@@ -54,6 +72,7 @@ if ($existing) {
     $targetResolved = if ($target) { (Resolve-Path $target -ErrorAction SilentlyContinue).Path } else { $null }
     if ($targetResolved -and $targetResolved -eq (Resolve-Path $source).Path) {
         Write-Host "Already installed: $LinkPath -> $source"
+        Set-CentreShim
         return
     }
     if ($targetResolved) { Write-Host "Re-pointing existing junction (was: $target)" }
@@ -64,4 +83,5 @@ if ($existing) {
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $LinkPath) | Out-Null
 New-Item -ItemType Junction -Path $LinkPath -Target $source | Out-Null
 Write-Host "Installed: $LinkPath -> $source"
+Set-CentreShim
 Write-Host "Claude Code loads junctioned skills live. Run /caesar <map-url> to check."

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -197,8 +197,14 @@ classed from memory is the one that reads as progress:
 
 Whenever he asks — "where are we", "what's left", "status" — run
 `scripts/status.ps1 -MapUrl <url> [<url> ...]` and show the table. That is the whole
-answer; there is no dashboard and no file on Drive, and he should never need GitHub's
-web UI.
+answer in chat, and he should never need GitHub's web UI.
+
+**The command centre** — every driven map on one page, regenerated every 60s at
+`%LOCALAPPDATA%\Caesar\command-centre\index.html` (`C:\Users\rajdh\AppData\Local\Caesar\command-centre\index.html`).
+Raj opens it himself with `caesar-centre` from any directory, and stops it with `caesar-centre
+stop`; name it when he asks for a picture wider than the map you are driving, and never start
+it for him:
+[`scripts/command-centre.ps1`](scripts/command-centre.ps1).
 
 Six facts per open ticket: number, title, type, **Who** (You / Caesar), **State**
 (Blocked → Queued → Ongoing), and blockers when blocked. Rows sort by what needs him.

--- a/skill/scripts/command-centre.ps1
+++ b/skill/scripts/command-centre.ps1
@@ -1,0 +1,169 @@
+<#
+.SYNOPSIS
+  The one command that opens the Caesar command centre (issue #184). Starts the
+  regenerator loop if it is not already running, then opens the page in the browser.
+
+.DESCRIPTION
+  A thin wrapper around watch-dashboard.ps1 (#183). It owns three things the loop
+  does not: where the page lives, how a second invocation attaches instead of
+  starting a second writer, and how the loop stops.
+
+  WHERE THE PAGE LIVES
+  %LOCALAPPDATA%\Caesar\command-centre\index.html - by default
+  C:\Users\<user>\AppData\Local\Caesar\command-centre\index.html.
+  The loop's own default is dashboard-output\index.html beside the script, which is
+  inside the repo working tree: a git clean deletes the page out from under an open
+  browser tab, and every worktree writes a different absolute path so the tab's URL
+  changes per checkout. %LOCALAPPDATA% is the Windows-sanctioned per-user
+  machine-local state directory: one fixed absolute path, unaffected by git, and -
+  unlike %APPDATA% - never roamed and never on the H:\ / C:\Numen Google Drive
+  letter, which corrupts file handles. So the browser tab survives a restart, a
+  reinstall and a branch switch.
+
+  LIVENESS
+  The loop's single-instance lock, the named mutex Global\CaesarDashboardLoop, is
+  the liveness test - it is probed cross-process with Mutex::OpenExisting, which
+  throws WaitHandleCannotBeOpenedException when no loop holds it. No PID file, no
+  second source of truth to go stale. The kill target is found separately, by
+  command line, because a mutex names no process.
+
+  AUTOSTART: RULED NO - the command centre does not start with Windows.
+  The refresh ruling (docs\research\command-centre-refresh.md section 4, loser c1)
+  already weighed a Scheduled Task and named it the upgrade path, not the shipping
+  shape, and nothing found here changes that. Two reasons it stays manual:
+  a logon-triggered loop spends the GraphQL budget - 1320 points/hour at the live
+  6-map set - on every day Raj never opens the board, and the budget is the binding
+  constraint the 60s interval was derived from; and a board nobody is looking at is
+  exactly where the refresh doc's worst failure mode (a stale page that reads as
+  healthy) does its damage unobserved. Starting it is one word, and that word is
+  said at the moment Raj actually wants to look.
+  What would change the call: Raj opening the board most days, or forgetting to
+  start it and reading stale numbers. Then register a logon-triggered task -
+  Register-ScheduledTask -TaskName 'Caesar Command Centre' -Trigger (New-ScheduledTaskTrigger -AtLogOn)
+    -Action (New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -File "<this script>" start')
+    -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable)
+  - and nothing else in this file moves.
+
+.EXAMPLE
+  caesar-centre
+.EXAMPLE
+  caesar-centre stop
+.EXAMPLE
+  powershell -File skill\scripts\command-centre.ps1 status
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [ValidateSet('start', 'stop', 'status')]
+    [string]$Verb = 'start',
+
+    [string]$OutFile = (Join-Path $env:LOCALAPPDATA 'Caesar\command-centre\index.html'),
+
+    [int]$IntervalSeconds = 60,
+
+    # How long a cold start waits for the loop's first sweep to produce a page before
+    # opening the browser. A whole sweep measures 9-14s at 6 maps (refresh doc section 1);
+    # this is the pessimistic ceiling, not the expectation.
+    [int]$FirstPageTimeoutSeconds = 180
+)
+
+$ErrorActionPreference = 'Stop'
+
+$MutexName = 'Global\CaesarDashboardLoop'
+$loopScript = Join-Path $PSScriptRoot 'watch-dashboard.ps1'
+if (-not (Test-Path -LiteralPath $loopScript)) { throw "No watch-dashboard.ps1 beside this script at $loopScript" }
+
+$OutFile = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine((Get-Location).Path, $OutFile))
+
+function Test-LoopAlive {
+    try {
+        $m = [System.Threading.Mutex]::OpenExisting($MutexName)
+        $m.Dispose()
+        return $true
+    } catch [System.Threading.WaitHandleCannotBeOpenedException] {
+        # the only "no loop" answer. Anything else - an access denial on a mutex that
+        # does exist - means something holds it, so it is not ours to start over.
+        return $false
+    }
+}
+
+# The mutex proves a loop is alive but names no process, so the kill target is found by
+# command line. Our own process does not match: it carries command-centre.ps1.
+function Get-LoopProcess {
+    @(Get-CimInstance Win32_Process -Filter "Name='powershell.exe'" |
+        Where-Object { $_.ProcessId -ne $PID -and $_.CommandLine -and $_.CommandLine -like '*watch-dashboard.ps1*' })
+}
+
+function Show-Status {
+    $alive = Test-LoopAlive
+    # @() again at the call site: a single-element array returned from a function is
+    # unrolled to the bare object, and .Count on a CimInstance is empty, not 1.
+    $procs = @(Get-LoopProcess)
+    Write-Host "Loop holding ${MutexName}: $alive"
+    Write-Host "watch-dashboard.ps1 processes: $($procs.Count)$(if ($procs) { ' (pid ' + (($procs | ForEach-Object { $_.ProcessId }) -join ', ') + ')' })"
+    Write-Host "Page: $OutFile$(if (Test-Path -LiteralPath $OutFile) { ' (generated ' + (Get-Item -LiteralPath $OutFile).LastWriteTime + ')' } else { ' (not generated yet)' })"
+}
+
+switch ($Verb) {
+
+    'status' { Show-Status }
+
+    'stop' {
+        $procs = @(Get-LoopProcess)
+        if (-not $procs) {
+            Write-Host "No command centre loop running."
+        } else {
+            foreach ($p in $procs) {
+                Stop-Process -Id $p.ProcessId -Force
+                Write-Host "Stopped loop process $($p.ProcessId)."
+            }
+            # Killing the process is what releases the mutex and the .tmp handle - the OS
+            # closes both handles at exit - so the mutex going unopenable is the receipt
+            # that the stop was clean, not just that the pid is gone.
+            $deadline = (Get-Date).AddSeconds(10)
+            while ((Test-LoopAlive) -and (Get-Date) -lt $deadline) { Start-Sleep -Milliseconds 200 }
+        }
+        if (Test-LoopAlive) { throw "$MutexName is still held after the stop - something else owns it." }
+        Write-Host "$MutexName released. No loop running."
+    }
+
+    'start' {
+        if (Test-LoopAlive) {
+            Write-Host "Command centre loop already running (pid $((Get-LoopProcess | ForEach-Object { $_.ProcessId }) -join ', ')). Attaching."
+        } else {
+            $outDir = Split-Path -Parent $OutFile
+            if (-not (Test-Path -LiteralPath $outDir)) { New-Item -ItemType Directory -Path $outDir -Force | Out-Null }
+
+            # Quoted explicitly: these are argv, and the repo's PowerShell rule is that a
+            # path with a space is shredded on the way through if it is not.
+            $loopArgs = @(
+                '-NoProfile', '-ExecutionPolicy', 'Bypass', '-WindowStyle', 'Hidden',
+                '-File', "`"$loopScript`"",
+                '-OutFile', "`"$OutFile`"",
+                '-IntervalSeconds', $IntervalSeconds
+            )
+            Start-Process -FilePath 'powershell.exe' -ArgumentList $loopArgs -WindowStyle Hidden
+            Write-Host "Started the command centre loop. Writing $OutFile every ${IntervalSeconds}s."
+
+            # Block until the child actually holds the mutex. It compiles the MoveFileEx
+            # P/Invoke with Add-Type before it locks, so for a few seconds after
+            # Start-Process the liveness probe still answers "no loop" - and a second
+            # start inside that window spawns a process that immediately exits 1.
+            $deadline = (Get-Date).AddSeconds(30)
+            while (-not (Test-LoopAlive) -and (Get-Date) -lt $deadline) { Start-Sleep -Milliseconds 250 }
+            if (-not (Test-LoopAlive)) { throw "The loop process was started but never took $MutexName. Run it in the foreground to see why: powershell -File `"$loopScript`" -OutFile `"$OutFile`"" }
+
+            if (-not (Test-Path -LiteralPath $OutFile)) {
+                Write-Host "Waiting for the first sweep (up to ${FirstPageTimeoutSeconds}s)..."
+                $deadline = (Get-Date).AddSeconds($FirstPageTimeoutSeconds)
+                while (-not (Test-Path -LiteralPath $OutFile) -and (Get-Date) -lt $deadline) { Start-Sleep -Seconds 2 }
+            }
+        }
+
+        if (-not (Test-Path -LiteralPath $OutFile)) {
+            throw "The loop is running but no page appeared at $OutFile. Run '$($MyInvocation.MyCommand.Name) status', then start the loop in the foreground to see its output: powershell -File `"$loopScript`" -OutFile `"$OutFile`""
+        }
+        Start-Process -FilePath $OutFile
+        Write-Host "Opened $OutFile"
+    }
+}


### PR DESCRIPTION
## What changed

- **New: `skill/scripts/command-centre.ps1`** — the one entry point, with three verbs.
  - `start` (default): if no loop is alive, launches `watch-dashboard.ps1` detached and hidden, waits for it to take the mutex, waits for the first page if there is none yet, then opens the page in the default browser. If a loop is already alive, it attaches — prints the pid and re-opens the page, spawning nothing.
  - `stop`: kills the loop process, then waits for `Global\CaesarDashboardLoop` to become unopenable and throws if it does not. The mutex going free is the receipt that the process handle and the `.tmp` handle are gone, not just that the pid is.
  - `status`: mutex state, process count and pids, page path and generation time. Exists so the invariant is checkable in one line.
- **`install.ps1`** now also writes `%LOCALAPPDATA%\Microsoft\WindowsApps\caesar-centre.cmd`, a two-line shim pointing at the junction (not at a checkout), and `-Uninstall` removes it. That directory is on the user PATH by default on Windows 11 and needs no elevation, so `caesar-centre` works from any directory with no PATH edit and no profile edit.
- **`skill/SKILL.md`** gained one pointer under *Showing Raj where things stand*, naming the page path and the command. The adjacent clause "there is no dashboard and no file on Drive" was amended to "…the whole answer in chat" — it is now false and would have told a session the command centre does not exist. That is the only non-pointer edit to `SKILL.md`.

**Nothing else moved.** `watch-dashboard.ps1`, `render-dashboard.ps1`, `dashboard-data.ps1` and `frontier.ps1` are byte-identical to `main`; the wrapper needed no change in any of them.

### Where the page lives, and why

`%LOCALAPPDATA%\Caesar\command-centre\index.html` — `C:\Users\rajdh\AppData\Local\Caesar\command-centre\index.html`.

The loop's own default is `dashboard-output\index.html` beside the script, which is inside the repo working tree: a `git clean` deletes the page out from under an open browser tab, and every worktree writes a different absolute path, so the tab's URL changes per checkout. `%LOCALAPPDATA%` is the Windows-sanctioned per-user machine-local state directory: one fixed absolute path, unaffected by git, and — unlike `%APPDATA%` — never roamed and never on the `H:\` / `C:\Numen` Google Drive letter that corrupts file handles. The tab survives a restart, a reinstall and a branch switch.

### Whether it starts with Windows — ruled **no**

The refresh ruling (`docs/research/command-centre-refresh.md` §4, loser c1) already weighed a Scheduled Task and named it the *upgrade path*, not the shipping shape. Nothing found on this ticket changes that, and two things argue against promoting it now:

- **Cost.** A logon-triggered loop spends 1320 GraphQL points/hour at the live 6-map set on every day Raj never opens the board. The GraphQL budget is the binding constraint the whole 60s interval was derived from (§3), and it is spent to keep a page fresh that nobody is reading.
- **Failure shape.** The refresh doc's worst failure mode is a stale board that reads as healthy. An always-on loop puts the board in exactly the state where that failure goes unobserved for days. Starting it deliberately means the freshest thing on screen is a page Raj asked for seconds ago.

Starting it is one word, and it is said at the moment he actually wants to look.

**What would change the call:** Raj opening the board most days, or catching himself reading stale numbers because he forgot to start it. The exact registration command is recorded in the script header (`skill/scripts/command-centre.ps1:42`) so the promotion is a copy-paste and nothing else in the file moves:

```powershell
Register-ScheduledTask -TaskName 'Caesar Command Centre' `
  -Trigger (New-ScheduledTaskTrigger -AtLogOn) `
  -Action (New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NoProfile -WindowStyle Hidden -File "<path>\command-centre.ps1" start') `
  -Settings (New-ScheduledTaskSettingsSet -StartWhenAvailable)
```

## Why

Ticket https://github.com/Dhillvn/Caesar/issues/184. The renderer and the loop landed in #183, but the board still had to be started by hand with a long path, wrote inside the repo tree, and had no stop. A dashboard Raj has to remember how to start is one he stops using.

## Proof it ran

Every line below is output observed on this machine (Windows 11, Windows PowerShell 5.1.26100.9168), against the live map set.

**Cold start, fresh shell, no loop alive** — the page did not exist at the ruled path at all; the wrapper waited for the loop's first sweep and then opened it:

```
Loop holding Global\CaesarDashboardLoop: False
watch-dashboard.ps1 processes: 0
Page: C:\Users\rajdh\AppData\Local\Caesar\command-centre\index.html (not generated yet)

Started the command centre loop. Writing C:\Users\rajdh\AppData\Local\Caesar\command-centre\index.html every 60s.
Waiting for the first sweep (up to 180s)...
Opened C:\Users\rajdh\AppData\Local\Caesar\command-centre\index.html
```

The page was then present at the ruled path, 32710 bytes, starting `<!doctype html>`. `.html` is associated (`assoc .html` → `.html=htmlfile`) and `Start-Process` on it returned without error, with browser processes running.

**The loop actually ticks it** — two observations of the page's `LastWriteTime` against the wall clock:

```
18:47:17   LastWriteTime 18:46:31      (first run, pid 6628)
18:49:29   LastWriteTime 18:48:59      (post-stop restart, pid 7060)
```

**The same command a second time — exactly one loop process:**

```
=== 2. cold start (fresh shell, no loop alive) ===
Started the command centre loop. ...
loop processes now = 1

=== 3. same command a second time ===
Command centre loop already running (pid 20492). Attaching.
Opened C:\Users\rajdh\AppData\Local\Caesar\command-centre\index.html
loop processes now = 1
Loop holding Global\CaesarDashboardLoop: True
watch-dashboard.ps1 processes: 1 (pid 20492)
```

**Clean stop, then a start straight afterwards:**

```
=== 5. clean stop ===
Stopped loop process 20492.
Global\CaesarDashboardLoop released. No loop running.
loop processes now = 0
Loop holding Global\CaesarDashboardLoop: False
watch-dashboard.ps1 processes: 0

=== 6. start straight afterwards ===
Started the command centre loop. ...
loop processes now = 1
Loop holding Global\CaesarDashboardLoop: True
watch-dashboard.ps1 processes: 1 (pid 7060)
```

An independent count excluding the querying process (`Get-CimInstance Win32_Process` filtered on command line, `ProcessId -ne $PID`) returned `0` after the stop.

**The shim** — `install.ps1` was exercised against a throwaway `-LinkPath` and `-ShimPath` in `%TEMP%` so the live `~/.claude/skills/caesar` junction was never re-pointed. It wrote the shim, was idempotent on re-run, resolved `caesar-centre status` **by bare name from `C:\`** with the temp bin dir on PATH (returning the same `%LOCALAPPDATA%` page path, confirming the default is environment-derived and not cwd-derived), and `-Uninstall` removed both the shim and the junction.

**Two bugs found and fixed during this proof**, both visible in the output above only because `status` prints the count:

1. `Get-LoopProcess` returned a single-element array, which PowerShell unrolls to a bare `CimInstance` whose `.Count` is empty — the process count printed blank. Fixed by re-wrapping in `@()` at the call site.
2. A `start` issued within a few seconds of another spawned a second process: the loop compiles its `MoveFileEx` P/Invoke with `Add-Type` *before* it takes the mutex, so the liveness probe still answered "no loop". The second copy always exited 1 on the mutex, so there was never a second writer, but `start` now blocks until the child actually holds the mutex, closing the window.

## Riskiest hunks

1. **`skill/scripts/command-centre.ps1:94`** — `Get-LoopProcess`, the command-line match that picks the kill target. It is the only thing `stop` aims at, and it matches on the substring `watch-dashboard.ps1` in any `powershell.exe` command line. `$PID` is excluded so the probe cannot match itself, but a *different* process whose command line happens to mention the loop script (a foreground debug run, an editor task) would be killed by `stop` too. Accepted: on this machine that string appears in nothing else, and the alternative — a PID file — is a second source of truth that goes stale exactly when it matters.
2. **`skill/scripts/command-centre.ps1:145`** — the detached `Start-Process powershell.exe` argv. This is the repo's PowerShell rule's home ground: both paths are explicitly quoted inside the array elements, because an unquoted path with a space is shredded on the way through and the failure is silent (a loop that starts, writes somewhere else, and looks fine). The ruled path has no space today; the quoting is what keeps that from being load-bearing.

## Blast radius, and reverting

Small and contained. Two files changed, one added; no frozen script touched; nothing on `H:` or `C:\Numen`; no new dependency — Windows PowerShell 5.1 and `Start-Process` only.

Outside the repo it creates exactly two things: `%LOCALAPPDATA%\Caesar\command-centre\` (the page) and `%LOCALAPPDATA%\Microsoft\WindowsApps\caesar-centre.cmd` (the shim, written only when `install.ps1` is re-run). No scheduled task, no service, no port, no registry write, no elevation.

Fully revertable: `git revert` restores `install.ps1` and `SKILL.md` and drops the new script. `install.ps1 -Uninstall` removes the shim; the leftover `%LOCALAPPDATA%\Caesar` directory is one `Remove-Item`. A loop already running is unaffected by the revert and is stopped with `caesar-centre stop` before it, or with `Stop-Process` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
