### PR TITLE
fix(dashboard): discovery must exclude closed maps

### DIFF
--- a/skill/references/multi-map.md
+++ b/skill/references/multi-map.md
@@ -9,10 +9,15 @@ A map is yours only while its issue carries **`caesar:driving`**. Discovery is o
 command:
 
 ```
-gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving
+gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving --state open
 ```
 
 `--owner` is mandatory — a label-only search returns twenty strangers' public maps.
+
+`--state open` is mandatory too, and for a subtler reason: the search covers **every**
+state by default, so a map closed by hand while still carrying `caesar:driving` comes back
+as a live map. `numen-ops#35` sat on the command centre that way for six weeks. The label
+is the claim, but the issue's state outranks it — a closed map is never being driven.
 
 **No state file.** GitHub reports which tickets are assigned and open; `git worktree
 list` reports what is still running. Both are already the truth, so a scratch file

--- a/skill/scripts/dashboard-data.ps1
+++ b/skill/scripts/dashboard-data.ps1
@@ -42,7 +42,12 @@ $OutputEncoding = [System.Text.Encoding]::UTF8
 $sweepScript = Join-Path $PSScriptRoot 'frontier.ps1'
 
 if (-not $MapUrl) {
-    $found = gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving --json url
+    # --state open is load-bearing: `gh search issues` searches every state by default,
+    # so a closed map that still carries caesar:driving is discovered and rendered as a
+    # live map. numen-ops#35 did exactly that - closed 2026-07-31, still labelled, still
+    # on the board six weeks later. The label is the claim, but the issue's state outranks
+    # it: a closed map is never being driven, whatever its labels say.
+    $found = gh search issues --owner Dhillvn --label wayfinder:map --label caesar:driving --state open --json url
     if ($LASTEXITCODE -ne 0) { throw "gh search issues failed" }
     $MapUrl = @(($found | ConvertFrom-Json) | ForEach-Object { $_.url })
 }


### PR DESCRIPTION
## What changed

`--state open` added to the map-discovery search in two places:

- `skill/scripts/dashboard-data.ps1:45` — the query the command centre sweeps from
- `skill/references/multi-map.md:12` — the same command as documented, which a Caesar session runs by hand

Both gained a comment explaining why the flag is load-bearing.

## Why

Raj closed `Dhillvn/numen-ops#35` by hand on 2026-07-31 and the command centre still showed it as a live map six weeks later. `gh search issues` searches **every state by default**, so a closed map that still carries `caesar:driving` is discovered and rendered as open. The label is the claim, but the issue state outranks it: a closed map is never being driven, whatever its labels say.

This is the general form of the data-hygiene problem the map at [#178](https://github.com/Dhillvn/Caesar/issues/178) recorded at charting — over half the board's output was noise from stale labels. Stripping the label fixes one instance; this fixes the class.

## Proof it ran

Measured against the live corpus, since the flag's behaviour is a property of `gh` rather than of this code:

```
default state, counts:   [{"n":34,"state":"closed"},{"n":7,"state":"open"}]
with --state open:       [{"n":7,"state":"open"}]
```

34 closed maps were reachable by the old query; the new one returns only the 7 open. The stale label on `numen-ops#35` was also stripped separately, so that instance is gone from the board independently of this change.

## Riskiest hunks

- `skill/scripts/dashboard-data.ps1:50` — the only behavioural line. It narrows discovery, so the failure mode if it were wrong is a map going *missing* from the board, not a stale one appearing. Checked against the live search above: all 7 open maps survive the filter.
- `skill/references/multi-map.md:12` — prose, no execution path, but it is what a session copies by hand, so leaving it stale would reintroduce the bug through the human path.

## Blast radius

Two files, one behavioural line. Explicit `-MapUrl` callers are untouched — the branch only runs when no map URL is passed. Fully revertable with a single `git revert`.
