### PR TITLE
fix(dashboard): decided tickets, copy-URL button, PR repo, and PR-to-map by branch

### DIFF
--- a/skill/scripts/dashboard-data.ps1
+++ b/skill/scripts/dashboard-data.ps1
@@ -74,16 +74,24 @@ $maps = foreach ($url in $MapUrl) {
         $lastDecided = if ($done.Count -gt 0) {
             [pscustomobject]@{ Number = $done[-1].Number; Title = $done[-1].Title; Url = $done[-1].Url }
         } else { $null }
+        # The whole decided list, newest first, so the page can show them without a trip
+        # to GitHub. $done is ascending by ClosedAt; the dropdown reads most-recent-first.
+        $decided = @($done | Sort-Object ClosedAt -Descending | ForEach-Object {
+            [pscustomobject]@{
+                Number = $_.Number; Title = $_.Title; Url = $_.Url
+                Type = $_.Type; ClosedAt = $_.ClosedAt
+            }
+        })
 
         [pscustomobject]@{
             Number = $mapNum; Title = $rows[0].MapTitle; Repo = $repo; Url = $url
             DoneCount = $done.Count; OpenCount = $open.Count
-            LastDecided = $lastDecided; OpenTickets = $open; Error = $null
+            LastDecided = $lastDecided; Decided = $decided; OpenTickets = $open; Error = $null
         }
     } catch {
         [pscustomobject]@{
             Number = $mapNum; Title = $null; Repo = $repo; Url = $url
-            DoneCount = 0; OpenCount = 0; LastDecided = $null; OpenTickets = @()
+            DoneCount = 0; OpenCount = 0; LastDecided = $null; Decided = @(); OpenTickets = @()
             Error = $_.Exception.Message
         }
     }
@@ -94,22 +102,35 @@ $slots = @($maps | ForEach-Object { $_.OpenTickets } | Where-Object { $_.Who -eq
 
 # ticket -> owning map number, so a PR's closing issue can be traced back to its
 # Dashboard Frame (#183: the gate groups PRs under the map they belong to).
+# Decided tickets are in the table too: a PR routinely lands against a ticket that is
+# already closed, and a table of open tickets alone answers "no map found" for it.
 $ticketMap = @{}
 foreach ($m in $maps) {
     foreach ($t in $m.OpenTickets) { $ticketMap[$t.Number] = $m.Number }
+    foreach ($t in $m.Decided) { $ticketMap[$t.Number] = $m.Number }
 }
 
 $repos = @($maps | Where-Object { $_.Repo } | ForEach-Object { $_.Repo } | Select-Object -Unique)
 $prs = foreach ($r in $repos) {
-    $json = gh pr list --repo $r --state open --json number,title,url,isDraft,createdAt,closingIssuesReferences
+    $json = gh pr list --repo $r --state open --json number,title,url,isDraft,createdAt,headRefName,closingIssuesReferences
     if ($LASTEXITCODE -ne 0) { throw "gh pr list failed for $r" }
     foreach ($pr in ($json | ConvertFrom-Json)) {
+        # closingIssuesReferences is populated only by a bare closing keyword - "Closes #71".
+        # Every Caesar PR body links its ticket inside a sentence ("Closes the funnel opened
+        # by [#71](...)"), which GitHub does not parse, so the array is empty on all of them
+        # and every PR rendered as "no map found for this PR's ticket". The branch name is
+        # the reliable carrier: spawn-ticket-agent.ps1 names every centurion branch
+        # ticket-<n>-<slug>.
         $closes = @($pr.closingIssuesReferences) | Select-Object -First 1
-        $ticket = if ($closes) { $closes.number } else { $null }
+        $ticket = if ($closes) {
+            $closes.number
+        } elseif ($pr.headRefName -match '^ticket-(\d+)(-|$)') {
+            [int]$Matches[1]
+        } else { $null }
         $mapNum = if ($ticket -and $ticketMap.ContainsKey($ticket)) { $ticketMap[$ticket] } else { $null }
         [pscustomobject]@{
             Number = $pr.number; Title = $pr.title; Url = $pr.url; Repo = $r; Draft = $pr.isDraft
-            ClosesTicket = $ticket; Map = $mapNum
+            Branch = $pr.headRefName; ClosesTicket = $ticket; Map = $mapNum
             AgeSeconds = [int](New-TimeSpan -Start ([datetime]$pr.createdAt) -End (Get-Date).ToUniversalTime()).TotalSeconds
         }
     }

--- a/skill/scripts/render-dashboard.ps1
+++ b/skill/scripts/render-dashboard.ps1
@@ -130,6 +130,26 @@ end {
         return $out
     }
 
+    # The decided tickets, behind the same disclosure the blocked ones use. They are the
+    # map's whole history, so the card would be unreadable with them open by default -
+    # and closed they cost one line. This is the whole reason Raj had to open GitHub.
+    function Decided-Html($map) {
+        $decided = @($map.Decided)
+        if ($decided.Count -eq 0) { return '' }
+        $rows = ($decided | ForEach-Object {
+            $when = if ($_.ClosedAt) { (Format-When $_.ClosedAt) } else { '&mdash;' }
+            '<div class="row drow">' +
+            "<a class=`"hit`" href=`"$($_.Url)`" aria-label=`"$(Esc $_.Title)`"></a>" +
+            "<span class=`"gl c-teal`">$([char]0x2713)</span>" +
+            "<span class=`"rn c-teal`">$($_.Number)</span>" +
+            "<span class=`"rt`"><a href=`"$($_.Url)`">$(Esc $_.Title)</a></span>" +
+            "<span class=`"col`">$(Esc $_.Type)</span>" +
+            "<span class=`"col`">$when</span></div>"
+        }) -join ''
+        return "<details class=`"blocked decided`"><summary>$($decided.Count) decided &mdash; show</summary>" +
+            '<div class="rows grp">' + $rows + '</div></details>'
+    }
+
     $maps = @($data.Maps)
 
     function Card-Html($map) {
@@ -148,7 +168,9 @@ end {
             '<span class="dot" style="background:#28c840"></span>' +
             "<span class=`"num`"><span class=`"hash`">#</span>$($map.Number)</span>" +
             "<span class=`"t`">$title</span>" +
-            "<span class=`"right`"><span class=`"repo`">$(Esc $map.Repo)</span>$live</span>" +
+            "<span class=`"right`">" +
+            "<button class=`"cpy mono`" type=`"button`" data-copy=`"$(Esc $map.Url)`" title=`"Copy the map URL`">copy url</button>" +
+            "<span class=`"repo`">$(Esc $map.Repo)</span>$live</span>" +
             '</div>' +
             '<div class="cbody">' +
             '<div class="chead">' +
@@ -158,6 +180,7 @@ end {
             '</div>' +
             "<div class=`"meta`">$($tickets.Count) open &middot; $blockedCt blocked &middot; $($map.DoneCount) decided</div>" +
             (Body-Html $map) +
+            (Decided-Html $map) +
             "<a class=`"more`" href=`"$($map.Url)`"><span>Open the map &rarr;</span></a>" +
             '</div></div>'
     }
@@ -196,7 +219,8 @@ end {
             $mapTitle = if ($mapTitleOf.ContainsKey($mapNum)) { Esc $mapTitleOf[$mapNum] } else { '' }
             $gateItems += "<div class=`"gmap`"><span class=`"gnum`">#$mapNum</span><span class=`"gt`">$mapTitle</span></div><ul>"
             foreach ($p in ($prs | Where-Object { $_.Map -eq $mapNum })) {
-                $sub = if ($p.ClosesTicket) { "closes #$($p.ClosesTicket) &middot; " } else { '' }
+                $sub = "$(Esc $p.Repo) &middot; "
+                if ($p.ClosesTicket) { $sub += "closes #$($p.ClosesTicket) &middot; " }
                 $sub += $(if ($p.Draft) { 'draft' } else { 'ready' })
                 $sub += " &middot; $(Format-Ago $p.AgeSeconds) old"
                 $gateItems += "<li><span class=`"n`">#$($p.Number)</span><span>" +
@@ -209,7 +233,8 @@ end {
         if ($unmapped.Count -gt 0) {
             $gateItems += '<div class="gmap"><span class="gnum">&mdash;</span><span class="gt">no map found for this PR&#39;s ticket</span></div><ul>'
             foreach ($p in $unmapped) {
-                $sub = $(if ($p.Draft) { 'draft' } else { 'ready' }) + " &middot; $(Format-Ago $p.AgeSeconds) old"
+                $sub = "$(Esc $p.Repo) &middot; " + $(if ($p.Draft) { 'draft' } else { 'ready' }) +
+                    " &middot; $(Format-Ago $p.AgeSeconds) old"
                 $gateItems += "<li><span class=`"n`">#$($p.Number)</span><span>" +
                     "<a href=`"$($p.Url)`">$(Esc $p.Title)</a>" +
                     "<span class=`"sub`">$sub</span></span></li>"
@@ -265,7 +290,7 @@ end {
 <head>
 <meta charset="utf-8">
 <meta http-equiv="refresh" content="30">
-<title>Caesar — command centre</title>
+<title>Caesar &mdash; command centre</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500&family=Geist+Mono:wght@400&display=swap" rel="stylesheet">
@@ -358,6 +383,15 @@ details.blocked summary{cursor:pointer;list-style:none;color:var(--graphite-mid)
   font:400 12px/1.6 var(--font-geist-mono);letter-spacing:-.24px;text-transform:uppercase}
 details.blocked summary::-webkit-details-marker{display:none}
 details.blocked summary:hover{color:var(--warm-granite)}
+details.decided summary{color:var(--teal-metric);opacity:.75}
+details.decided summary:hover{color:var(--teal-metric);opacity:1}
+.row.drow{grid-template-columns:18px 52px 1fr 104px 150px}
+.cpy{appearance:none;background:transparent;border:1px solid var(--ash-stroke);
+  border-radius:var(--radius-buttons);color:var(--warm-granite);cursor:pointer;
+  padding:4px 8px;font:400 12px/1 var(--font-geist-mono);letter-spacing:-.24px;
+  text-transform:uppercase}
+.cpy:hover{color:var(--bone);border-color:var(--warm-granite)}
+.cpy.ok{color:var(--teal-metric);border-color:var(--teal-metric)}
 .more{margin-top:20px;display:inline-block;color:var(--bone);font:400 14px/1 var(--font-geist)}
 .more span{border-bottom:1px solid var(--ash-stroke);padding-bottom:6px}
 .more:hover span{color:var(--chalk);border-color:var(--chalk)}
@@ -475,6 +509,40 @@ $banner
     <div class="foot-note mono">Generated $genStr &middot; Factory, with Numen's two accents &middot; read-only, links out to GitHub</div>
   </footer>
 </div>
+<script>
+/* The page's only script. It reads nothing and renders nothing - every value above is
+   still baked in at render time (see .DESCRIPTION) - it exists so the map URL reaches
+   the clipboard in one click instead of a right-click through the "Open the map" link.
+   navigator.clipboard is undefined on some file:// origins, hence the execCommand
+   fallback; the page is opened from %LOCALAPPDATA%, not over http. */
+document.addEventListener('click', function (e) {
+  var b = e.target.closest ? e.target.closest('.cpy') : null;
+  if (!b) return;
+  e.preventDefault();
+  var text = b.getAttribute('data-copy');
+  var done = function () {
+    var was = b.textContent;
+    b.textContent = 'copied';
+    b.classList.add('ok');
+    setTimeout(function () { b.textContent = was; b.classList.remove('ok'); }, 1200);
+  };
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(done, function () { fallback(text, done); });
+  } else {
+    fallback(text, done);
+  }
+  function fallback(t, ok) {
+    var ta = document.createElement('textarea');
+    ta.value = t;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); ok(); } catch (err) { b.textContent = 'copy failed'; }
+    document.body.removeChild(ta);
+  }
+});
+</script>
 </body>
 </html>
 "@


### PR DESCRIPTION
## What changed

Four command-centre gaps reported from real use, plus one pre-existing rendering bug found on the way.

- **Decided tickets are on the page.** `dashboard-data.ps1` exported only `LastDecided`, so a map's history was reachable only on GitHub. The whole closed set now ships as `Decided` (newest first, with type and closed date) and renders behind the same `<details>` disclosure the blocked tickets already use — closed by default, one line when closed.
- **A copy-url button on every card bar.** Previously the map URL came out only by right-clicking "Open the map" and copying the link address. This adds the page's first and only client script: it reads nothing and renders nothing, so every value on the page is still baked in at render time and the "a static file cannot age its own clock" property in `.DESCRIPTION` is untouched. `navigator.clipboard` with a `document.execCommand` fallback, because the page is opened from `%LOCALAPPDATA%` over `file://`.
- **The gate says which repo a PR is in**, on both the mapped and the unmapped lines. Map cards already showed repo; the gate did not.
- **`no map found for this PR's ticket` on every PR — two independent causes, both fixed.** `closingIssuesReferences` is populated only by a bare closing keyword (`Closes #71`); every Caesar PR body links its ticket inside a sentence — numen-site#74 reads *"Closes the funnel opened by [#71](...)"* — which GitHub does not parse, so the array was empty on all of them. The branch name is now the fallback carrier, since `spawn-ticket-agent.ps1` names every centurion branch `ticket-<n>-<slug>`. Separately, the ticket→map table was built from **open** tickets only, so a PR closing an already-decided ticket could not resolve even with a good reference; decided tickets are in the table now.
- **Page-title mojibake** (pre-existing): a raw em dash in a BOM-less `.ps1` is read as ANSI by PowerShell 5.1 and re-encoded on write, so the browser tab read `Caesar â€” command centre`. Now `&mdash;`. `render-dashboard.ps1` is ASCII-only again, which is what kept every other glyph correct — they all go through `[char]0x….`

Not a code change, recorded here because it was half the report: `Dhillvn/numen-cloudtalk#2` was missing from the board because it carried `wayfinder:map` but not `caesar:driving`, which is what discovery filters on. Label added; the map now sweeps.

## Why

Reported directly against the live board. No ticket — this is a bug-fix batch on the command centre shipped by #181/#183/#184.

## Proof it ran

Dogfooded against live data, not a fixture.

- `dashboard-data.ps1` — exit 0, 192 KB. Six maps, `Decided` populated on all six and matching `DoneCount` exactly: `#2 numen-cloudtalk 4/4`, `#264 numen-ops 12/12`, `#6 numen-site 40/40`, `#220 numen-ops 21/21`, `#164 numen-ops 15/15`, `#17 numen-ops 27/27`. `numen-cloudtalk#2` appears for the first time.
- `render-dashboard.ps1` — 93 KB page. Six `decided — show` disclosures with the right counts, six `.cpy` buttons carrying the right map URLs, gate line reads `Dhillvn/numen-cloudtalk · draft · 30h old`. `<details>` tags balanced: 6 decided + 4 blocked open, 10 close.
- The branch fallback, run against real merged branch names: `ticket-75-confirmed-composite → 75`, `ticket-71-sourcing-review → 71`, `ticket-12-design-spec → 12`, `ticket-9 → 9`, `feat/dial-loop → (none)`, `main → (none)`.
- End-to-end: tickets 71, 75 and 12 all resolve to map #6 through the new table, so numen-site#74 (branch `ticket-71-sourcing-review`) would now group under its map. Before this change it resolved through neither path.
- The client script extracted and `node --check`ed: parses clean.

**Not verified in a browser.** `chrome-devtools-axi` would not hold a session across invocations on this machine (three attempts; it relaunches and exits each time, `open` succeeds and the next command cannot connect). So the copy button's *behaviour* — clipboard write and the "copied" flash — is unexercised; its markup, styling and syntax are verified. Worth one click before merging.

## Riskiest hunks

1. `skill/scripts/dashboard-data.ps1:118` — the branch fallback fires only when `closingIssuesReferences` is empty, so a real GitHub link still wins. A hand-named branch that happens to start `ticket-<n>` on a non-Caesar PR would mis-attribute; the anchored `^ticket-(\d+)(-|$)` keeps that to branches following Caesar's own convention.
2. `skill/scripts/render-dashboard.ps1:483` — the new `<script>` sits inside a PowerShell here-string, where `$` interpolates. It contains no `$`, verified by the page rendering and parsing clean, but any future edit to it must stay `$`-free or be escaped.

## Blast radius

Two scripts, both pure: `dashboard-data.ps1` only adds fields (nothing removed, `LastDecided` still exported for the empty-frontier line), `render-dashboard.ps1` only writes an HTML file. No GitHub writes, no worktrees, no dispatch path touched. The page regenerates every 60s, so a revert takes effect within one sweep. Fully revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
